### PR TITLE
Render full-screen map button

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jsdom-global": "^3.0.2",
     "leaflet-timedimension": "^1.1.1",
     "leaflet.markercluster": "^1.4.1",
+    "leaflet-fullscreen": "^1.0.2",
     "live-server": "^1.2.1",
     "mocha": "^7.1.0",
     "mocha-jsdom": "^2.0.0",

--- a/src/iframe/map2.html
+++ b/src/iframe/map2.html
@@ -7,6 +7,8 @@
         integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
         crossorigin="" />
     <script src="../../node_modules/leaflet/dist/leaflet.js"></script>
+    <script src="../../node_modules/leaflet-fullscreen/dist/Leaflet.fullscreen.js"></script>
+    <link rel="stylesheet" type="text/css" href="../../node_modules/leaflet-fullscreen/dist/leaflet.fullscreen.css">
     <link rel="stylesheet" type="text/css" href="css/IframeStyle.css">
     <script src="js/third-party/leaflet-sidebar.js"></script>
     <link rel="stylesheet" type="text/css" href="css/third-party/leaflet-sidebar.css">


### PR DESCRIPTION
Map2 already had the fullscreenControl option, but it wasn't being used. 
Modified map2.html and package.json: added leaflet-fullscreen package to show a fullscreen button below the zoom buttons.
