### PR TITLE
Added Skew Correcting on Color Coding

### DIFF
--- a/src/iframe/js/library/autoQuery.js
+++ b/src/iframe/js/library/autoQuery.js
@@ -379,20 +379,20 @@ class AutoQuery {
       * @returns {string} hex color code
       */
     getColor(properties) {
-        let propsVarName;
         let value;
         if (this.color.variable) {
-            propsVarName = Util.removePropertiesPrefix(this.color.variable);
+            const propsVarName = Util.removePropertiesPrefix(this.color.variable);
             value = properties[propsVarName];
         }
         const skew = this.color.skew != null ? this.color.skew + 1 : 1;
+        const skewDir = this.color.skewDir != null ? this.color.skewDir : "right";
         switch (this.colorStyle) {
             case "solid":
                 return this.colorCode;
             case "gradient":
-                const range = this.getConstraintMetadata(this.color.variable).range;
+                const range = this.getConstraintMetadata(this.color.variable).range; 
                 const normalizedValue = (value - range[0]) / (range[1] - range[0]);
-                const skewCorrectedValue = Math.pow(normalizedValue, 1 / skew); // https://www.desmos.com/calculator/rarbpgoalk
+                const skewCorrectedValue = skewDir === "right" ?  Math.pow(normalizedValue, 1 / skew) : Math.pow(normalizedValue, skew); // https://www.desmos.com/calculator/4qpxsz2pdg
                 console.log(`Before skew: ${normalizedValue}`)
                 console.log(`After skew: ${skewCorrectedValue}`)
                 const colorindex = Math.round(skewCorrectedValue * 32); //normalizes value on range. results in #1 - 32

--- a/src/iframe/js/library/autoQuery.js
+++ b/src/iframe/js/library/autoQuery.js
@@ -381,18 +381,19 @@ class AutoQuery {
       * @returns {string} hex color code
       */
     getColor(properties) {
+        const propsVarName = Util.removePropertiesPrefix(this.color.variable);
+        const value = properties[propsVarName];
         switch (this.colorStyle) {
             case "solid":
                 return this.colorCode;
             case "gradient":
-                const value = properties[this.color.variable];
                 const range = this.getConstraintMetadata(this.color.variable).range;
                 const normalizedValue = Math.round((value - range[0]) / (range[1] - range[0]) * 32); //normalizes value on range. results in #1 - 32
                 return this.colorCode[normalizedValue];
+            case "logGradient":
+                const skew = this.color.skew;
             case "sequential":
-                const varName = Util.removePropertiesPrefix(this.color.variable);
-                const v = properties[varName];
-                const index = this.getConstraintMetadata(this.color.variable).options.indexOf(v);
+                const index = this.getConstraintMetadata(this.color.variable).options.indexOf(value);
                 return this.colorCode[index];
         }
     }

--- a/src/iframe/js/library/autoQuery.js
+++ b/src/iframe/js/library/autoQuery.js
@@ -392,7 +392,7 @@ class AutoQuery {
             case "gradient":
                 const range = this.getConstraintMetadata(this.color.variable).range; 
                 const normalizedValue = (value - range[0]) / (range[1] - range[0]);
-                const skewCorrectedValue = skewDir === "right" ?  (1 - (Math.pow(1 - normalizedValue,skew))) : Math.pow(normalizedValue, skew); // https://www.desmos.com/calculator/ww74bpjmxv
+                const skewCorrectedValue = skewDir === "right" ?  (1 - (Math.pow(1 - normalizedValue,skew))) : Math.pow(normalizedValue, skew); // https://www.desmos.com/calculator/gezo3xfbfj
                 const colorindex = Math.round(skewCorrectedValue * 32); //normalizes value on range. results in #1 - 32
                 return this.colorCode[colorindex];
             case "sequential":

--- a/src/iframe/js/library/autoQuery.js
+++ b/src/iframe/js/library/autoQuery.js
@@ -392,9 +392,7 @@ class AutoQuery {
             case "gradient":
                 const range = this.getConstraintMetadata(this.color.variable).range; 
                 const normalizedValue = (value - range[0]) / (range[1] - range[0]);
-                const skewCorrectedValue = skewDir === "right" ?  Math.pow(normalizedValue, 1 / skew) : Math.pow(normalizedValue, skew); // https://www.desmos.com/calculator/4qpxsz2pdg
-                console.log(`Before skew: ${normalizedValue}`)
-                console.log(`After skew: ${skewCorrectedValue}`)
+                const skewCorrectedValue = skewDir === "right" ?  Math.pow(normalizedValue, 1 / skew) : Math.pow(normalizedValue, skew); // https://www.desmos.com/calculator/ww74bpjmxv
                 const colorindex = Math.round(skewCorrectedValue * 32); //normalizes value on range. results in #1 - 32
                 return this.colorCode[colorindex];
             case "sequential":

--- a/src/iframe/js/library/autoQuery.js
+++ b/src/iframe/js/library/autoQuery.js
@@ -392,7 +392,7 @@ class AutoQuery {
             case "gradient":
                 const range = this.getConstraintMetadata(this.color.variable).range; 
                 const normalizedValue = (value - range[0]) / (range[1] - range[0]);
-                const skewCorrectedValue = skewDir === "right" ?  Math.pow(normalizedValue, 1 / skew) : Math.pow(normalizedValue, skew); // https://www.desmos.com/calculator/ww74bpjmxv
+                const skewCorrectedValue = skewDir === "right" ?  (1 - (Math.pow(1 - normalizedValue,skew))) : Math.pow(normalizedValue, skew); // https://www.desmos.com/calculator/ww74bpjmxv
                 const colorindex = Math.round(skewCorrectedValue * 32); //normalizes value on range. results in #1 - 32
                 return this.colorCode[colorindex];
             case "sequential":

--- a/src/iframe/json/menumetadata.json
+++ b/src/iframe/json/menumetadata.json
@@ -307,9 +307,10 @@
       "style": "gradient",
       "variable": "RISK_SCORE",
       "gradient": [
-        "#0057e3",
-        "#ff8000"
-      ]
+        "#00FF00",
+        "#FF0000"
+      ],
+      "skew":1.5
     },
     "fieldMetadata": [
       {
@@ -330,9 +331,10 @@
       "style": "gradient",
       "variable": "RISK_SCORE",
       "gradient": [
-        "#0057e3",
-        "#ff8000"
-      ]
+        "#00FF00",
+        "#FF0000"
+      ],
+      "skew":1.5
     },
     "fieldMetadata": [
       {

--- a/src/iframe/json/menumetadata.json
+++ b/src/iframe/json/menumetadata.json
@@ -310,7 +310,7 @@
         "#00FF00",
         "#FF0000"
       ],
-      "skew":1.5
+      "skew":1
     },
     "fieldMetadata": [
       {
@@ -334,7 +334,8 @@
         "#00FF00",
         "#FF0000"
       ],
-      "skew":1.5
+      "skew":1,
+      "border": 1
     },
     "fieldMetadata": [
       {


### PR DESCRIPTION
Made it so you can correct for skewing in a dataset during color-coding.

Here is the basic idea: https://www.desmos.com/calculator/px5vxgzujw
In that example, s = how skewed the value you are color coding on is.
Green = correction for right skewness.
Purple = correction for left skewness.
Red = how it is if you don't set skew for a dataset or skew is set to 0