### PR TITLE
Administrative Tracts may now overlap

### DIFF
--- a/src/iframe/js/library/autoQuery.js
+++ b/src/iframe/js/library/autoQuery.js
@@ -233,11 +233,12 @@ class AutoQuery {
                 return;
             Util.normalizeFeatureID(GeoJSON)
             GeoJSON.id = `${GeoJSON.properties}_${data.id}`
+            if (this.layerIDs.includes(GeoJSON.id))
+                return;
             GeoJSON.properties = {
                 ...GeoJSON.properties,
                 ...data
             }
-            console.log(GeoJSON.properties)
             data = GeoJSON;
         }
 

--- a/src/iframe/js/library/autoQuery.js
+++ b/src/iframe/js/library/autoQuery.js
@@ -231,11 +231,13 @@ class AutoQuery {
             const GeoJSON = this.backgroundLoader.getGeometryFromGISJOIN(data.GISJOIN, forcedGeometry);
             if (!GeoJSON)
                 return;
-
+            Util.normalizeFeatureID(GeoJSON)
+            GeoJSON.id = `${GeoJSON.properties}_${data.id}`
             GeoJSON.properties = {
                 ...GeoJSON.properties,
                 ...data
             }
+            console.log(GeoJSON.properties)
             data = GeoJSON;
         }
 

--- a/src/iframe/js/library/autoQuery.js
+++ b/src/iframe/js/library/autoQuery.js
@@ -228,11 +228,11 @@ class AutoQuery {
       */
     renderData(data, forcedGeometry) {
         if (this.linked) {
-            const GeoJSON = this.backgroundLoader.getGeometryFromGISJOIN(data.GISJOIN, forcedGeometry);
+            const GeoJSON = JSON.parse(JSON.stringify(this.backgroundLoader.getGeometryFromGISJOIN(data.GISJOIN, forcedGeometry)));
             if (!GeoJSON)
                 return;
             Util.normalizeFeatureID(GeoJSON)
-            GeoJSON.id = `${GeoJSON.properties}_${data.id}`
+            GeoJSON.id = `${GeoJSON.id}_${data.id}`
             if (this.layerIDs.includes(GeoJSON.id))
                 return;
             GeoJSON.properties = {

--- a/src/iframe/js/library/geometryLoader.js
+++ b/src/iframe/js/library/geometryLoader.js
@@ -122,7 +122,6 @@ class GeometryLoader {
         });
 
         this.queryWorker.port.onmessage = msg => {
-            console.log(msg);
             if (msg.data.type === "data") {
                 let data = msg.data.data;
                 Util.normalizeFeatureID(data);


### PR DESCRIPTION
Made it so different county/tract features don't get rejected by `renderGeoJson` by setting the id to a combination of the data, and the county/tract id.

closes #159 