### PR TITLE
Fix "xfeat is undefined" bug in scatterplots

### DIFF
--- a/src/iframe/js/library/charting/scatterplotManager.js
+++ b/src/iframe/js/library/charting/scatterplotManager.js
@@ -75,7 +75,9 @@ class ScatterplotManager {
 
     axisButtonCallback(axis, direction) {
         this.currentFeatures[axis] = this.nextValidFeatureForAxis(axis, direction);
-        this.update(this.system.getValues());
+        this.system.getValues().then((values) => {
+            this.update(values);
+        });
     }
 
     nextValidFeatureForAxis(axis, direction) {


### PR DESCRIPTION
Remember when I said I didn't think getValues() being async would cause any problems?