### PR TITLE
Filter sampling

### DIFF
--- a/src/iframe/js/library/charting/chartSystem.js
+++ b/src/iframe/js/library/charting/chartSystem.js
@@ -84,7 +84,7 @@ class ChartSystem {
 
         this.chartFrames = [];
 
-        this.valueIngester = new ValueIngester(filter);
+        this.valueIngester = new ValueIngester(this.filter);
 
         this.resizable = new resizable(400, 300, "white");
         this.resizable.setResizeCallback((width, height) => {
@@ -110,7 +110,7 @@ class ChartSystem {
 
         let area = new type.areaType();
         area.attachTo(node);
-        let manager = new type.managerType(this.catalog, area, this.validFeatureManager, this, type.chartType);
+        let manager = new type.managerType(this.catalog, area, this.valueIngester.featureManager, this, type.chartType);
         let frame = new ChartFrame(node, area, manager);
 
         this.chartFrames.push(frame);
@@ -131,30 +131,32 @@ class ChartSystem {
         // TODO: This needs to not suck
         this.resizable.triggerResizeEvent();
 
-        this.valueIngester.setSamplingPercentage(this.getIdealSamplePercent(map.getZoom()));
-        let values = await this.valueIngester.getValues();
+        this.valueIngester.setSamplingPercentage(this.getIdealSamplePercent(this.map.getZoom()));
+        let values = await this.getValues();
+
         this.chartFrames.forEach(frame => { frame.manager.update(values); });
 
         this.doNotUpdate = true;
         window.setTimeout(() => { this.doNotUpdate = false; }, 200);
     }
 
+    async getValues() {
+        return this.valueIngester.getValuesInBound(this.graphable, this.map.getBounds());
+    }
 
     getIdealSamplePercent(zoomAmount) {
-        // At around 7 zoom level, multiple states are visible.
+        // At around 8 zoom level, multiple states start becoming visible.
         // We should start reducing the sample percentage around here.
         // At 5 zoom level, the entire contiguous US is visible. 
         // The sample level should be very low here.
         // This doesn't provide a very wide range of options, which is
         // why this computation is so stilted.
-        if (zoomAmount > 7) {
+        if (zoomAmount > 8) {
             return 1.0;
-        } else if (zoomAmount == 7) {
-            return 0.7;
-        } else if (zoomAmount == 6) {
+        } else if (zoomAmount == 8) {
             return 0.5;
-        } else if (zoomAmount == 5) {
-            return 0.2;
+        } else if (zoomAmount == 7) {
+            return 0.3;
         } else {
             return 0.1;
         }

--- a/src/iframe/js/library/charting/scatterplotManager.js
+++ b/src/iframe/js/library/charting/scatterplotManager.js
@@ -75,7 +75,9 @@ class ScatterplotManager {
 
     axisButtonCallback(axis, direction) {
         this.currentFeatures[axis] = this.nextValidFeatureForAxis(axis, direction);
-        this.update(this.system.getValues());
+        this.system.getValues().then((values) => {
+            this.update(values);
+        });
     }
 
     nextValidFeatureForAxis(axis, direction) {

--- a/src/iframe/js/library/mapDataFilter.js
+++ b/src/iframe/js/library/mapDataFilter.js
@@ -84,14 +84,17 @@ class MapDataFilter {
      * feature, whose key is the name of the feature requested and whose 
      * value is a list of all of the values associated with that feature
      * found in the data set.
+     * @param {string} feature - the feature to model
+     * @param {Array<object>} data - the data to create the model from
+     * @param {number} samplePercent - Optional float between 0-1 describing what percent of the data to sample (1 by default)
      */
-    getModel(feature, bounds) {
+    getModel(feature, bounds, samplePercent) {
         let filteredData = this.filter(this.data, bounds);
 
         if (Array.isArray(feature)) {
-            return this.getMultipleModel(feature, filteredData);
+            return this.getMultipleModel(feature, filteredData, samplePercent);
         } else {
-            return this.getSingleModel(feature, filteredData);
+            return this.getSingleModel(feature, filteredData, samplePercent);
         }
     }
 
@@ -139,13 +142,17 @@ class MapDataFilter {
       * @method getSingleModel
       * @param {string} feature - the feature to model
       * @param {Array<object>} data - the data to create the model from
+      * @param {number} samplePercent - Optional float between 0-1 describing what percent of the data to sample (1 by default)
       * returns {object} the model
       */
-    getSingleModel(feature, data) {
+    getSingleModel(feature, data, samplePercent) {
         const model = {};
         model[feature] = [];
 
-        for (const datum of data) {
+        let step = samplePercent ? (1 / samplePercent) : 1;
+
+        for (let i = 0; i < data.length; i = Math.round(i + step)) {
+            let datum = data[i];
             if (datum.properties[feature] !== undefined) {
                 model[feature].push(this.model(datum, feature));
             }
@@ -170,6 +177,7 @@ class MapDataFilter {
             type: this.dataLocation(entry),
             locationName: entry.properties.NAME10,
             feature: feature,
+            GISJOIN: entry.properties.GISJOIN,
         };
     }
 
@@ -196,13 +204,14 @@ class MapDataFilter {
       * @method getSingleModel
       * @param {Array<string>} features The features to model
       * @param {Array<object>} data The data to create the model from
-      * returns {Array<object>} the models
+      * @param {number} samplePercent - Optional float between 0-1 describing what percent of the data to sample (1 by default)
+      * @returns {Array<object>} the models
       */
-    getMultipleModel(features, data) {
+    getMultipleModel(features, data, samplePercent) {
         let model = {};
 
         for (const feature of features) {
-            const singleModel = this.getSingleModel(feature, data);
+            const singleModel = this.getSingleModel(feature, data, samplePercent);
             model = { ...model, ...singleModel };
         }
 

--- a/src/iframe/js/library/mapDataFilterWorker.js
+++ b/src/iframe/js/library/mapDataFilterWorker.js
@@ -9,7 +9,7 @@ onmessage = function (msg) {
         filter.add(data.data, data.collection);
     }
     else if (data.type === "get") {
-        const values = filter.getModel(data.feature,data.bounds);
+        const values = filter.getModel(data.feature, data.bounds, data.samplingPercent);
         postMessage({
             type: "getResponse",
             senderID: data.senderID,

--- a/src/iframe/js/library/mapDataFilterWrapper.js
+++ b/src/iframe/js/library/mapDataFilterWrapper.js
@@ -8,7 +8,7 @@ const MapDataFilterWrapper = {
             collection: collection
         });
     },
-    get: async (feature, bounds) => {
+    get: async (feature, bounds, samplingPercent) => {
         //create ID to know if response is for me
         const senderID = Math.random().toString(36).substring(2, 6);
         return new Promise((resolve, reject) => {
@@ -26,6 +26,7 @@ const MapDataFilterWrapper = {
                 type: "get",
                 feature: feature,
                 bounds: bounds,
+                samplingPercent: samplingPercent,
                 senderID: senderID
             });
         });

--- a/src/iframe/js/library/valueIngester.js
+++ b/src/iframe/js/library/valueIngester.js
@@ -69,8 +69,8 @@ class ValueIngester {
         this.samplingPercent = percent;
     }
 
-    async getValues() {
-        let values = await this.filter.get(this.graphable, this.map.getBounds(), this.samplingPercent);
+    async getValuesInBound(features, bounds) {
+        let values = await this.filter.get(features, bounds, this.samplingPercent);
 
         // This arcane incantation gets a list of feature names for which there's actually data.
         // Don't ask.

--- a/src/iframe/map2.html
+++ b/src/iframe/map2.html
@@ -55,6 +55,7 @@
     <script src="js/library/apertureUtil.js"></script>
     <script src="js/library/resizable.js"></script>
     <script src="js/library/mapDataFilterWrapper.js"></script>
+    <script src="js/library/valueIngester.js"></script>
     <script src="js/library/geohash_util.js"></script>
 
     <script src="js/library/renderInfrastructure.js"></script>


### PR DESCRIPTION
At low zoom levels, the filter now samples data instead of passing ALL of it to the charts. The amount of sampling coarsely increases as the map is zoomed out.

For reference, if you zoom to see about a third of the contiguous US, you would normally get about ~1,000-1,500 counties appear in the graph if there was no sampling. In this branch, the amount should be greatly reduced.

Later there probably should be some UI element alerting the user that sampling is taking place, or else the results may be unexpected. 