### PR TITLE
Qualified feature names

### DIFF
--- a/src/iframe/js/library/charting/Feature.js
+++ b/src/iframe/js/library/charting/Feature.js
@@ -1,0 +1,41 @@
+
+/** A simple data transfer object to store a feature name and its collection.
+ *  Also contains some utility functions.
+ */
+class Feature {
+    /** Build a Feature object.
+     *  @param {string} collection The name of the collection
+     *  @param {string} name The name of the feature
+     *  @param {string} friendlyName A human-readable version of the feature name
+     */
+    constructor(collection, name, friendlyName) {
+        this.collection = collection;
+        this.name = name;
+        this.friendlyName = friendlyName;
+    }
+    
+    /** The full name of a feature includes the name of its collection and the
+     *  feature's own name.
+     *  For instance, the name of county SVI is "svi_county/RPL_THEMES".
+     */
+    getFullName() {
+        return `${collection}/${name}`;
+    }
+
+    /** Extract just the collection from a full feature name.
+     *  @param {string} fullName The full name of a feature (collection + name);
+     *  @returns {string} Just the collection name
+     */
+    static getCollectionFromFullName(fullName) {
+        return fullName.substring(0, fullName.indexOf('/'));
+    }
+    
+    /** Extract just the feature name from a full feature name.
+     *  (i.e. remove the collection name).
+     *  @param {string} fullName The full name of a feature (collection + name);
+     *  @returns {string} Just the feature name
+     */
+    static getFeatureNameFromFullName(fullName) {
+        return fullName.substring(fullName.indexOf('/') + 1);
+    }
+}

--- a/src/iframe/js/library/charting/chartBtnControls.js
+++ b/src/iframe/js/library/charting/chartBtnControls.js
@@ -70,7 +70,7 @@ function createDropdown(chart, title, axis) {
             dropdownItem.onclick = ()=> {
                 chart.changeFeature(axis, feature);
             }
-            dropdownItem.innerText = feature;
+            dropdownItem.innerText = Feature.getFriendlyName(feature);
             dropdownMenu.appendChild(dropdownItem);
         });
     });

--- a/src/iframe/js/library/charting/chartSystem.js
+++ b/src/iframe/js/library/charting/chartSystem.js
@@ -99,7 +99,7 @@ class ChartSystem {
             this.catalog = catalog;
             this.graphable = catalog.map(e => {
                 return Object.entries(e.constraints).map(kv => {
-                    return new Feature(kv[0], e.collection, kv[1].label);
+                    return Feature.compose(e.collection, kv[0], kv[1].label);
                 })
             }).flat();
             console.log(this.graphable);

--- a/src/iframe/js/library/charting/chartSystem.js
+++ b/src/iframe/js/library/charting/chartSystem.js
@@ -102,7 +102,6 @@ class ChartSystem {
                     return Feature.compose(e.collection, kv[0], kv[1].label);
                 })
             }).flat();
-            console.log(this.graphable);
         });
 
         this.doNotUpdate = false;
@@ -149,6 +148,7 @@ class ChartSystem {
         // This arcane incantation gets a list of feature names for which there's actually data.
         // Don't ask.
         let validFeatures = Object.entries(values).filter(kv => kv[1].length !== 0).map(kv => kv[0]);
+
         this.validFeatureManager.update(validFeatures);
 
         return values;

--- a/src/iframe/js/library/charting/chartSystem.js
+++ b/src/iframe/js/library/charting/chartSystem.js
@@ -97,7 +97,12 @@ class ChartSystem {
         $.getJSON(chartCatalogFilename, (catalog) => {
             this.initializeUpdateHooks();
             this.catalog = catalog;
-            this.graphable = catalog.map(e => Object.keys(e.constraints)).flat();
+            this.graphable = catalog.map(e => {
+                return Object.entries(e.constraints).map(kv => {
+                    return new Feature(kv[0], e.collection, kv[1].label);
+                })
+            }).flat();
+            console.log(this.graphable);
         });
 
         this.doNotUpdate = false;

--- a/src/iframe/js/library/charting/feature.js
+++ b/src/iframe/js/library/charting/feature.js
@@ -1,33 +1,17 @@
 
-/** A simple data transfer object to store a feature name and its collection.
- *  Also contains some utility functions.
- */
 class Feature {
-    /** Build a Feature object.
-     *  @param {string} collection The name of the collection
-     *  @param {string} name The name of the feature
-     *  @param {string} friendlyName A human-readable version of the feature name
-     */
-    constructor(collection, name, friendlyName) {
-        this.collection = collection;
-        this.name = name;
-        this.friendlyName = friendlyName;
+    static featurePattern = /(.+)::(.+)::(.+)/;
+
+    static compose(collection, name, friendlyName) {
+        return `${collection}::${name}::${friendlyName}`;
     }
     
-    /** The full name of a feature includes the name of its collection and the
-     *  feature's own name.
-     *  For instance, the name of county SVI is "svi_county::RPL_THEMES".
-     */
-    getFullName() {
-        return `${collection}/${name}`;
-    }
-
     /** Extract just the collection from a full feature name.
      *  @param {string} fullName The full name of a feature (collection + name);
      *  @returns {string} Just the collection name
      */
-    static getCollectionFromFullName(fullName) {
-        return fullName.substring(0, fullName.indexOf('/'));
+    static getCollection(fullName) {
+        return fullName.match(Feature.featurePattern)[1];
     }
     
     /** Extract just the feature name from a full feature name.
@@ -35,7 +19,15 @@ class Feature {
      *  @param {string} fullName The full name of a feature (collection + name);
      *  @returns {string} Just the feature name
      */
-    static getFeatureNameFromFullName(fullName) {
-        return fullName.substring(fullName.indexOf('/') + 1);
+    static getName(fullName) {
+        return fullName.match(Feature.featurePattern)[2];
+    }
+
+    /** Extract just the human-readable name from a full feature name.
+     *  @param {string} fullName The full name of a feature (collection + name);
+     *  @returns {string} Just the human-readable name
+     */
+    static getFriendlyName(fullName) {
+        return fullName.match(Feature.featurePattern)[3];
     }
 }

--- a/src/iframe/js/library/charting/feature.js
+++ b/src/iframe/js/library/charting/feature.js
@@ -16,7 +16,7 @@ class Feature {
     
     /** The full name of a feature includes the name of its collection and the
      *  feature's own name.
-     *  For instance, the name of county SVI is "svi_county/RPL_THEMES".
+     *  For instance, the name of county SVI is "svi_county::RPL_THEMES".
      */
     getFullName() {
         return `${collection}/${name}`;

--- a/src/iframe/js/library/charting/scatterplotManager.js
+++ b/src/iframe/js/library/charting/scatterplotManager.js
@@ -123,12 +123,15 @@ class ScatterplotManager {
         let xfeat = values[this.currentFeatures.x];
         let yfeat = values[this.currentFeatures.y];
         let shorterFeature = (xfeat.length > yfeat.length) ? yfeat : xfeat; 
-        for (let i = 0; i < shorterFeature.length; i++) {
+
+        let joins = shorterFeature.map(d => d.GISJOIN);
+        
+        joins.forEach(gisjoin => {
             data.push({
-                x: xfeat[i].data,
-                y: yfeat[i].data,
+                x: xfeat.find(d => d.GISJOIN === gisjoin).data,
+                y: yfeat.find(d => d.GISJOIN === gisjoin).data,
             });
-        }
+        });
 
         data.x = Feature.getFriendlyName(this.currentFeatures.x);
         data.y = Feature.getFriendlyName(this.currentFeatures.y);

--- a/src/iframe/js/library/charting/scatterplotManager.js
+++ b/src/iframe/js/library/charting/scatterplotManager.js
@@ -135,8 +135,8 @@ class ScatterplotManager {
             
             if (xEntry && yEntry) {
                 data.push({
-                    x: xfeat.find(d => d.GISJOIN === gisjoin).data,
-                    y: yfeat.find(d => d.GISJOIN === gisjoin).data,
+                    x: xEntry.data,
+                    y: yEntry.data,
                 });
             }
         });

--- a/src/iframe/js/library/charting/scatterplotManager.js
+++ b/src/iframe/js/library/charting/scatterplotManager.js
@@ -130,10 +130,15 @@ class ScatterplotManager {
 
         let joins = shorterFeature.map(d => d.GISJOIN);
         joins.forEach(gisjoin => {
-            data.push({
-                x: xfeat.find(d => d.GISJOIN === gisjoin).data,
-                y: yfeat.find(d => d.GISJOIN === gisjoin).data,
-            });
+            let xEntry = xfeat.find(d => d.GISJOIN === gisjoin);
+            let yEntry = yfeat.find(d => d.GISJOIN === gisjoin);
+            
+            if (xEntry && yEntry) {
+                data.push({
+                    x: xfeat.find(d => d.GISJOIN === gisjoin).data,
+                    y: yfeat.find(d => d.GISJOIN === gisjoin).data,
+                });
+            }
         });
 
         data.x = Feature.getFriendlyName(this.currentFeatures.x);

--- a/src/iframe/js/library/charting/scatterplotManager.js
+++ b/src/iframe/js/library/charting/scatterplotManager.js
@@ -130,26 +130,8 @@ class ScatterplotManager {
             });
         }
 
-        let readableXName = this.catalog.find(e => {
-            for (let constraint in e.constraints) {
-                if (constraint === this.currentFeatures.x) {
-                    return true;
-                }
-            }
-            return false;
-        }).constraints[this.currentFeatures.x].label;
-
-        let readableYName = this.catalog.find(e => {
-            for (let constraint in e.constraints) {
-                if (constraint === this.currentFeatures.y) {
-                    return true;
-                }
-            }
-            return false;
-        }).constraints[this.currentFeatures.y].label;
-
-        data.x = readableXName;
-        data.y = readableYName;
+        data.x = Feature.getFriendlyName(this.currentFeatures.x);
+        data.y = Feature.getFriendlyName(this.currentFeatures.y);
 
         return data;
     }

--- a/src/iframe/js/library/charting/scatterplotManager.js
+++ b/src/iframe/js/library/charting/scatterplotManager.js
@@ -124,7 +124,7 @@ class ScatterplotManager {
         let yfeat = values[this.currentFeatures.y];
         let shorterFeature = (xfeat.length > yfeat.length) ? yfeat : xfeat; 
 
-        if (xfeat[0].type !== yfeat[0].type) {
+        if (shorterFeature.length === 0 || xfeat[0].type !== yfeat[0].type) {
             return [];
         }
 

--- a/src/iframe/js/library/charting/scatterplotManager.js
+++ b/src/iframe/js/library/charting/scatterplotManager.js
@@ -124,8 +124,11 @@ class ScatterplotManager {
         let yfeat = values[this.currentFeatures.y];
         let shorterFeature = (xfeat.length > yfeat.length) ? yfeat : xfeat; 
 
+        if (xfeat[0].type !== yfeat[0].type) {
+            return [];
+        }
+
         let joins = shorterFeature.map(d => d.GISJOIN);
-        
         joins.forEach(gisjoin => {
             data.push({
                 x: xfeat.find(d => d.GISJOIN === gisjoin).data,

--- a/src/iframe/js/library/charting/singleChartManager.js
+++ b/src/iframe/js/library/charting/singleChartManager.js
@@ -63,17 +63,12 @@ class SingleChartManager {
         this.featureManager = validFeatureManager;
         this.currentFeature = this.featureManager.getAnyFeature();
 
-        let graphable = catalog.map(e => Object.keys(e.constraints)).flat();
-
-        this.constraints = catalog.map(e => e.constraints);
-        this.constraints.forEach(constraint => {
-            for (let feature in constraint) {
-                this.charts[feature] = new chartType();
-                this.charts[feature].setTitle(constraint[feature].label);
-                this.chartArea.addChart(this.charts[feature]);
-            }
-        });
-        this.chartArea.tellNumberOfCharts(graphable.length);
+        this.chartSystem.graphable.forEach(feature => {
+            this.charts[feature.fullName] = new chartType();
+            this.charts[feature.fullName].setTitle(feature.friendlyName);
+            this.chartArea.addChart(this.charts[feature.fullName]);
+        })
+        this.chartArea.tellNumberOfCharts(this.chartSystem.graphable.length);
 
         this.chartArea.setFeatureToggleCallback(() => {
             this.cycleAxis("x");
@@ -97,6 +92,7 @@ class SingleChartManager {
     }
 
     update(values) {
+        console.log(values);
         let enoughFeatures = this.featureManager.enoughFeaturesExist(1);
 
         if (enoughFeatures) {

--- a/src/iframe/js/library/charting/singleChartManager.js
+++ b/src/iframe/js/library/charting/singleChartManager.js
@@ -64,9 +64,9 @@ class SingleChartManager {
         this.currentFeature = this.featureManager.getAnyFeature();
 
         this.chartSystem.graphable.forEach(feature => {
-            this.charts[feature.fullName] = new chartType();
-            this.charts[feature.fullName].setTitle(feature.friendlyName);
-            this.chartArea.addChart(this.charts[feature.fullName]);
+            this.charts[feature] = new chartType();
+            this.charts[feature].setTitle(Feature.getFriendlyName(feature));
+            this.chartArea.addChart(this.charts[feature]);
         })
         this.chartArea.tellNumberOfCharts(this.chartSystem.graphable.length);
 
@@ -92,7 +92,6 @@ class SingleChartManager {
     }
 
     update(values) {
-        console.log(values);
         let enoughFeatures = this.featureManager.enoughFeaturesExist(1);
 
         if (enoughFeatures) {

--- a/src/iframe/js/library/mapDataFilter.js
+++ b/src/iframe/js/library/mapDataFilter.js
@@ -117,7 +117,9 @@ class MapDataFilter {
       */
     filter(data, bounds) {
         // oh god
-        let filtered = Object.values(data).map(coll => coll.filter(datum => Util.isInBounds(datum, bounds))).flat();
+        let filtered = Object.entries(data).map(kv => { 
+            return { collection: kv[0], data: kv[1].filter(datum => Util.isInBounds(datum, bounds)) };
+        });
 
         // Now that unchecking collections nukes whole parts of the dataset, this probably isn't necessary
         //this.discardOldData(this.msCacheMaxAge);
@@ -146,14 +148,19 @@ class MapDataFilter {
       * returns {object} the model
       */
     getSingleModel(feature, data) {
+        let featureCollection = Feature.getCollection(feature);
+        let featureName = Feature.getName(feature);
+
         const model = {};
         model[feature] = [];
 
-        for (const datum of data) {
-            if (datum.properties[Feature.getName(feature)] !== undefined) {
-                model[feature].push(this.model(datum, feature));
-            }
-        }
+        data.forEach(entry => {
+            entry.data.forEach(datum => {
+                if (entry.collection === featureCollection && datum.properties[featureName]) {
+                    model[feature].push(this.model(datum, feature));
+                }
+            });
+        });
 
         return model;
     }

--- a/src/iframe/js/library/mapDataFilter.js
+++ b/src/iframe/js/library/mapDataFilter.js
@@ -145,11 +145,11 @@ class MapDataFilter {
       */
     getSingleModel(feature, data) {
         const model = {};
-        model[feature] = [];
+        model[feature.getFullName()] = [];
 
         for (const datum of data) {
-            if (datum.properties[feature] !== undefined) {
-                model[feature].push(this.model(datum, feature));
+            if (datum.properties[feature.name] !== undefined) {
+                model[feature.getFullName()].push(this.model(datum, feature));
             }
         }
 
@@ -168,7 +168,7 @@ class MapDataFilter {
       */
     model(entry, feature) { 
         return { 
-            data: entry.properties[feature],
+            data: entry.properties[feature.name],
             type: this.dataLocation(entry),
             locationName: entry.properties.NAME10,
             feature: feature,

--- a/src/iframe/js/library/mapDataFilter.js
+++ b/src/iframe/js/library/mapDataFilter.js
@@ -1,3 +1,5 @@
+importScripts('./charting/feature.js');
+
 /**
  * @class  MapDataFilter
  * @author Pierce Smith
@@ -145,11 +147,11 @@ class MapDataFilter {
       */
     getSingleModel(feature, data) {
         const model = {};
-        model[feature.fullName] = [];
+        model[feature] = [];
 
         for (const datum of data) {
-            if (datum.properties[feature.name] !== undefined) {
-                model[feature.fullName].push(this.model(datum, feature));
+            if (datum.properties[Feature.getName(feature)] !== undefined) {
+                model[feature].push(this.model(datum, feature));
             }
         }
 
@@ -168,7 +170,7 @@ class MapDataFilter {
       */
     model(entry, feature) { 
         return { 
-            data: entry.properties[feature.name],
+            data: entry.properties[Feature.getName(feature)],
             type: this.dataLocation(entry),
             locationName: entry.properties.NAME10,
             feature: feature,

--- a/src/iframe/js/library/mapDataFilter.js
+++ b/src/iframe/js/library/mapDataFilter.js
@@ -181,6 +181,7 @@ class MapDataFilter {
             type: this.dataLocation(entry),
             locationName: entry.properties.NAME10,
             feature: feature,
+            GISJOIN: entry.properties.GISJOIN,
         };
     }
 

--- a/src/iframe/js/library/mapDataFilter.js
+++ b/src/iframe/js/library/mapDataFilter.js
@@ -145,11 +145,11 @@ class MapDataFilter {
       */
     getSingleModel(feature, data) {
         const model = {};
-        model[feature.getFullName()] = [];
+        model[feature.fullName] = [];
 
         for (const datum of data) {
             if (datum.properties[feature.name] !== undefined) {
-                model[feature.getFullName()].push(this.model(datum, feature));
+                model[feature.fullName].push(this.model(datum, feature));
             }
         }
 

--- a/src/iframe/json/graphPriority.json
+++ b/src/iframe/json/graphPriority.json
@@ -17,7 +17,20 @@
     "label": "Social Vulnerability Index (County)",
     "constraints": {
       "RPL_THEMES": {
-        "label": "Social Vulnerability Index",
+        "label": "Social Vulnerability Index (County)",
+        "priority": 2,
+        "graphTypes": ["bar", "histogram"],
+        "buckets": [[0.0,0.2],[0.2,0.4],[0.4,0.6],[0.6,0.8],[0.8,1.0]],
+        "color scheme": []
+      }
+    }
+  },
+  {
+    "collection": "svi_tract_GISJOIN",
+    "label": "Social Vulnerability Index (Tract)",
+    "constraints": {
+      "RPL_THEMES": {
+        "label": "Social Vulnerability Index (Tract)",
         "priority": 2,
         "graphTypes": ["bar", "histogram"],
         "buckets": [[0.0,0.2],[0.2,0.4],[0.4,0.6],[0.6,0.8],[0.8,1.0]],

--- a/src/iframe/map2.html
+++ b/src/iframe/map2.html
@@ -41,6 +41,7 @@
     <script src="js/model-managers/clusterManager.js"></script>
     <script src="js/model-managers/regressionManager.js"></script>
     <!-- Charting includes -->
+    <script src="js/library/charting/feature.js"></script>
     <script src="js/library/charting/chartFrame.js"></script>
     <script src="js/library/charting/validFeatureManager.js"></script>
     <script src="js/library/charting/chart.js"></script>


### PR DESCRIPTION
Lots of internal changes that amount to the following things:
- Charts can now tell the difference between identically named constraints, i.e. things like SVI county and SVI tract are now separately plottable and will not be confused with one another.
- Human-readable names are now much easier to get (Closes #212).
- Scatterplots are now actually meaningful (guess what? Data coming into the scatterplots previously wasn't being joined on _anything_, meaning the distribution of data was effectively random. They are now properly joined by GISJOIN. Having to admit that I designed the world's most useless scatterplot was hard.)

Charting _may_ be noticeably slower with these changes, especially scatterplots.