### PR TITLE
More chart QOL

### DIFF
--- a/src/css/charts.css
+++ b/src/css/charts.css
@@ -61,18 +61,19 @@
     position: absolute;
     bottom: 0px;
     left: 0px;
-    overflow: auto;
+    border: 1px solid #777;
+    border-radius: 3px;
+    box-sizing: border-box;
 }
 
 .overlay .box{
     width: 100%;
     height: 100%;
-    /*border: 1px solid #777;*/
-    /*border-radius: 3px;*/
-    /*box-sizing: border-box;*/
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
-.overlay .box .option{
+.overlay .option{
     width: 15px;
     height: 15px;
     border-radius: 50%;
@@ -81,7 +82,7 @@
     position: absolute;
 }
 
-.overlay .box .option.top-right {
+.overlay .option.top-right {
     right: -5px;
     top: -5px;
     cursor: nesw-resize;

--- a/src/js/library/charting/chartFrame.js
+++ b/src/js/library/charting/chartFrame.js
@@ -18,6 +18,7 @@ export default class ChartFrame {
     }
 
     resize() { 
+        console.log(this.height);
         this.area.rerender(this.width, this.height);
     }
 

--- a/src/js/library/charting/chartFrame.js
+++ b/src/js/library/charting/chartFrame.js
@@ -18,7 +18,6 @@ export default class ChartFrame {
     }
 
     resize() { 
-        console.log(this.height);
         this.area.rerender(this.width, this.height);
     }
 

--- a/src/js/library/charting/chartSystem.js
+++ b/src/js/library/charting/chartSystem.js
@@ -90,6 +90,8 @@ export const ChartingType = {
 }
 
 export default class ChartSystem {
+    static MAX_CHART_HEIGHT = 350;
+
     constructor(map, chartCatalogFilename) {
         this.map = map;
 
@@ -102,7 +104,12 @@ export default class ChartSystem {
         this.resizable = new resizable(400, 300, "white");
         this.resizable.setResizeCallback((width, height) => {
             this.chartFrames.forEach(frame => {
-                frame.setSize(width - 200, height - 200);
+                let newHeight = height - 200;
+                if (newHeight > ChartSystem.MAX_CHART_HEIGHT) {
+                    newHeight = ChartSystem.MAX_CHART_HEIGHT;
+                }
+
+                frame.setSize(width - 200, newHeight);
                 frame.resize();
             });
         });

--- a/src/js/library/charting/singleChartManager.js
+++ b/src/js/library/charting/singleChartManager.js
@@ -97,12 +97,10 @@ export default class SingleChartManager {
         let enoughFeatures = this.featureManager.enoughFeaturesExist(1);
 
         if (enoughFeatures) {
-            // this.chartArea.hideNotEnoughFeaturesMessage();
             for (let feature in values) {
                 this.charts[feature].changeData(values[feature].map(e => e.data), 5);
             }
         } else {
-            // this.chartArea.showNotEnoughFeaturesMessage();
             this.chartArea.hideAll();
         }
     }

--- a/src/js/library/resizable.js
+++ b/src/js/library/resizable.js
@@ -60,7 +60,8 @@ END OF TERMS AND CONDITIONS
 * Author Jean-Marc
 */
 export default class resizable {
-    minimum_size = 20;
+    static minimum_width = 500;
+    static minimum_height = 100;
     // Allows us to add listeners to the unique overlays
     static numOfInstances = 0;
     // Each time a overlay is clicked its Z Index increases so it is seen above all other overlays
@@ -163,10 +164,10 @@ export default class resizable {
     changeBoxSize(e, dimensions){
         this.width = dimensions[0] + (e.pageX - dimensions[3]);
         this.height = dimensions[1] - (e.pageY - dimensions[4]);
-        if (this.width > this.minimum_size) {
+        if (this.width > resizable.minimum_width) {
             this.overlayDocument.style.width = this.width + 'px';
         }
-        if (this.height > this.minimum_size) {
+        if (this.height > resizable.minimum_height) {
             this.overlayDocument.style.height = this.height + 'px';
             this.overlayDocument.style.top = dimensions[2] + (e.pageY - dimensions[4]) + 'px';
         }

--- a/src/js/library/resizable.js
+++ b/src/js/library/resizable.js
@@ -92,6 +92,7 @@ export default class resizable {
         overlayDocument.style.width = this.width + "px";
         overlayDocument.style.height = this.height + "px";
         overlayDocument.style.zIndex = resizable.zIndex;
+        overlayDocument.style.left = window.innerWidth - this.width + "px";
         overlayDocument.style.display = "none";
         overlayDocument.style.opacity = .9;
 
@@ -106,7 +107,7 @@ export default class resizable {
         boxResizer.id = "option" + this.uniqueId;
         boxResizer.className = "option top-right";
 
-        boxDocument.appendChild(boxResizer);
+        overlayDocument.appendChild(boxResizer);
         overlayDocument.appendChild(boxDocument);
         document.body.appendChild(overlayDocument);
     }


### PR DESCRIPTION
Makes charting suck a little bit less.

* The resizable handle should now show up properly (isn't cut off) and should sit in the same place in the top right corner no matter where the window is scrolled to (Closes #216 - doesn't put the handle in all 4 corners, but I think it solves the spirit of the problem, that being resizing was way to cumbersome and annoying)
* The charting window should no longer appear underneath the menu when first activated (Closes #217)
* There is no more useless horizontal scrollbar (Closes #226)
* Charts now have a maximum size, allowing multiple to show up if given adequate space (Closes #214)
* Other small improvements to look and feel