### PR TITLE
Fix large numeric datasets breaking KDE

### DIFF
--- a/src/js/library/charting/histogram.js
+++ b/src/js/library/charting/histogram.js
@@ -116,7 +116,6 @@ export default class Histogram extends Chart {
         if (this.kdeEnabled) {
             let maxBarHeight = d3.max(this.bins, d => d.length);
             let kdePoints = this.kde.estimate(view.x.ticks(30), this.data, maxBarHeight);
-            console.log(kdePoints);
 
             view.kdeLine = d3.line()
                 .curve(d3.curveBasis)
@@ -189,8 +188,8 @@ export default class Histogram extends Chart {
             .append("xhtml:input")
             .attr("name", "bwslider")
             .attr("type", "range")
-            .attr("min", 0.1)
-            .attr("max", 1)
+            .attr("min", 0.4)
+            .attr("max", 10)
             .attr("step", "any")
             .attr("id", "kdeSlider");
 

--- a/src/js/library/charting/histogram.js
+++ b/src/js/library/charting/histogram.js
@@ -115,7 +115,8 @@ export default class Histogram extends Chart {
 
         if (this.kdeEnabled) {
             let maxBarHeight = d3.max(this.bins, d => d.length);
-            let kdePoints = this.kde.normalize(this.kde.estimate(view.x.ticks(30), this.data), maxBarHeight);
+            let kdePoints = this.kde.estimate(view.x.ticks(30), this.data, maxBarHeight);
+            console.log(kdePoints);
 
             view.kdeLine = d3.line()
                 .curve(d3.curveBasis)
@@ -188,8 +189,8 @@ export default class Histogram extends Chart {
             .append("xhtml:input")
             .attr("name", "bwslider")
             .attr("type", "range")
-            .attr("min", -1)
-            .attr("max", 2)
+            .attr("min", 0.1)
+            .attr("max", 1)
             .attr("step", "any")
             .attr("id", "kdeSlider");
 
@@ -200,11 +201,10 @@ export default class Histogram extends Chart {
         let histogram = this;
         svg.select("foreignObject input#kdeSlider").node().oninput = function() { 
             if (histogram.kdeEnabled) {
-                let transformedValue = Math.exp(this.value);
-                kde.setBandwidth(transformedValue); 
+                kde.setBandwidth(this.value); 
 
                 svg.select("foreignObject div text")
-                    .text(`${transformedValue.toPrecision(2)}`)
+                    .text(`${Number.parseFloat(this.value).toPrecision(2)}`)
 
                 histogram.rerenderAllViews();
             }

--- a/src/js/library/charting/kernelDensityEstimator.js
+++ b/src/js/library/charting/kernelDensityEstimator.js
@@ -15,16 +15,30 @@ export default class KernelDensityEstimator {
         this.bandwidth = bw;
     }
 
-    estimate(thresholds, data) {
-        return thresholds.map(t => [t, d3.mean(data, d => this.kernel(this.bandwidth)(t - d))]);
-    }
+    estimate(thresholds, data, maxY) {
+        let normalize = d3.scaleLinear()
+            .domain([thresholds[0], thresholds[thresholds.length - 1]])
+            .range([0, 1]);
 
-    normalize(estimate, upperBound) {
-        let maxPoint = d3.max(estimate, d => d[1]);
-        return estimate.map(p => [p[0], p[1] / maxPoint * upperBound]);
+        let unnormalizeThresholds = d3.scaleLinear()
+            .domain([0, 1])
+            .range([thresholds[0], thresholds[thresholds.length - 1]]);
+
+        let unnormalizeData = d3.scaleLinear()
+            .domain([0, 1])
+            .range([0, maxY]);
+
+        data = data.map(e => normalize(e));
+        thresholds = thresholds.map(e => normalize(e));
+
+        let estimate = thresholds.map(t => [t, d3.mean(data, d => this.kernel(this.bandwidth)(t - d))]);
+        estimate = estimate.map(e => [unnormalizeThresholds(e[0]), unnormalizeData(e[1])]);
+        return estimate;
     }
 
     epanechnikov(bandwidth) {
-        return x => Math.abs(x /= bandwidth) <= 1 ? 0.75 * (1 - x * x) / bandwidth : 0;
+        return x => {
+            return Math.abs(x /= bandwidth) <= 1 ? 0.75 * (1 - x * x) / bandwidth : 0;
+        }
     }
 }

--- a/src/js/library/charting/kernelDensityEstimator.js
+++ b/src/js/library/charting/kernelDensityEstimator.js
@@ -18,21 +18,21 @@ export default class KernelDensityEstimator {
     estimate(thresholds, data, maxY) {
         let normalize = d3.scaleLinear()
             .domain([thresholds[0], thresholds[thresholds.length - 1]])
-            .range([0, 1]);
+            .range([0, 10]);
 
-        let unnormalizeThresholds = d3.scaleLinear()
-            .domain([0, 1])
+        let unnormalize = d3.scaleLinear()
+            .domain([0, 10])
             .range([thresholds[0], thresholds[thresholds.length - 1]]);
-
-        let unnormalizeData = d3.scaleLinear()
-            .domain([0, 1])
-            .range([0, maxY]);
 
         data = data.map(e => normalize(e));
         thresholds = thresholds.map(e => normalize(e));
 
         let estimate = thresholds.map(t => [t, d3.mean(data, d => this.kernel(this.bandwidth)(t - d))]);
-        estimate = estimate.map(e => [unnormalizeThresholds(e[0]), unnormalizeData(e[1])]);
+        estimate = estimate.map(e => [unnormalize(e[0]), unnormalize(e[1])]);
+
+        let maxEstimate = d3.max(estimate, d => d[1]);
+        let fit = d3.scaleLinear().domain([0, maxEstimate]).range([0, maxY]);
+        estimate = estimate.map(e => [e[0], fit(e[1])]);
         return estimate;
     }
 


### PR DESCRIPTION
Datasets with large individual entries, notably median household income, should no longer cause KDE in histograms to stop working.
Closes #252 .