### PR TITLE
Remove Blocker Warning if Layer Unchecked

### DIFF
--- a/src/js/library/autoQuery.js
+++ b/src/js/library/autoQuery.js
@@ -312,7 +312,6 @@ export default class AutoQuery {
 
     checkAndDispatch(oldBlockers) {
         if (oldBlockers !== JSON.stringify(AutoQuery.blockers)) {
-            console.log(AutoQuery.blockers)
             AutoQuery.dispatchBlocker();
         }
     }

--- a/src/js/ui/DefensiveOptimization.js
+++ b/src/js/ui/DefensiveOptimization.js
@@ -24,7 +24,7 @@ export default function DefensiveOptimization(props) {
 
     const HEIGHT_PER_ALERT = 65;
     const height = (Object.values(blockers)
-        .map(curr => { return Number(curr) })
+        .map(curr => { return Number(curr !== 0) })
         .reduce((acc, curr) => {
             return acc + curr;
         }, 0) * HEIGHT_PER_ALERT).toString() + "px";


### PR DESCRIPTION
Fixed a bug where if you were zoomed out far enough, for a defensive optimization warning to come up, and then unchecked the layer causing it, the warning would persist. This involved making the flag which sets which blockers are on into integers, because the user may select multiple layers.