### PR TITLE
Dark mode charts + resizing fixes

### DIFF
--- a/src/js/library/charting/chart.js
+++ b/src/js/library/charting/chart.js
@@ -118,6 +118,18 @@ export default class Chart {
         this.views[viewIndex].svg.style("display", "block");
     }
 
+    isDarkMode() {
+        return document.querySelector('html').getAttribute('data-theme') === 'dark';
+    }
+
+    getBasicThemeColor() {
+        return this.isDarkMode() ? "#eee" : "#111";
+    }
+
+    getInvertedThemeColor() {
+        return this.isDarkMode() ? "#333" : "#ccc";
+    }
+
     // To be overriden in subclasses.
     makeNewView(node, width, height) { }
     rerender(width, height, viewIndex) { }

--- a/src/js/library/charting/controlDropdown.js
+++ b/src/js/library/charting/controlDropdown.js
@@ -60,8 +60,12 @@ export default class ControlDropdown {
         this.chartControlButtonGroup = this.createChartControlButtonGroup();
         this.chartDropdown = this.createDropdown(frame, title);
         this.chartControlButtonGroup.appendChild(this.chartDropdown);
+        
+        this.frame = frame;
 
-        this.dropdownButton.onclick = () => frame.update();
+        this.dropdownButton.onclick = () => {
+            frame.update();
+        }
     }
 
     getDOMNode() {
@@ -124,7 +128,10 @@ export default class ControlDropdown {
         for (let option of options) {
             let dropdownItem = document.createElement("a");
             dropdownItem.className = "dropdown-item dropdown-menu-item-custom";
-            dropdownItem.onclick = option.onclick
+            dropdownItem.onclick = () => {
+                option.onclick();
+                this.frame.update();
+            }
             dropdownItem.innerText = option.name;
             this.dropdownMenu.appendChild(dropdownItem);
         }

--- a/src/js/library/charting/histogram.js
+++ b/src/js/library/charting/histogram.js
@@ -114,6 +114,7 @@ export default class Histogram extends Chart {
             .attr("x", newWidth / 2)
             .attr("y", 24)
             .attr("text-anchor", "middle")
+            .attr("fill", this.getBasicThemeColor())
             .text(this.title);
 
         if (this.kdeEnabled) {
@@ -126,6 +127,7 @@ export default class Histogram extends Chart {
                 .y(d => view.y(d[1]));
             view.svg.select("path#kdecurve")
                 .datum(kdePoints)
+                .attr("stroke", this.getBasicThemeColor())
                 .attr("d", view.kdeLine)
                 .attr("display", "default");
         } else {
@@ -171,7 +173,6 @@ export default class Histogram extends Chart {
         view.svg.append("text").attr("id", "title");
         view.svg.append("path").attr("id", "kdecurve")
             .attr("fill", "none")
-            .attr("stroke", "#000")
             .attr("stroke-width", 1.5)
             .attr("stroke-linejoin", "round");
 

--- a/src/js/library/charting/lineGraph.js
+++ b/src/js/library/charting/lineGraph.js
@@ -118,11 +118,12 @@ export default class LineGraph extends Chart {
             .selectAll("path")
             .data(this.data)
             .join("path")
-            .style("mix-blend-mode", "multiply")
+            .style("mix-blend-mode", this.isDarkMode() ? "screen" : "multiply")
             .attr("d", d => view.line(d.data));
 
         view.svg.select("text#title")
             .attr("x", width / 2)
+            .attr("fill", this.getBasicThemeColor())
             .text(this.title);
 
         view.svg.select("text#subtitle")
@@ -201,7 +202,8 @@ export default class LineGraph extends Chart {
             .attr("stroke-width", 1.5)
             .attr("stroke-linejoin", "round")
             .attr("stroke-linecap", "round");
-        view.svg.append("text").attr("id", "title")
+        view.svg.append("text")
+            .attr("id", "title")
             .attr("y", 12)
             .attr("text-anchor", "middle");
         view.svg.append("text").attr("id", "marker");
@@ -225,6 +227,8 @@ export default class LineGraph extends Chart {
             if (this.data.length === 0) {
                 return;
             }
+
+            let chart = this;
 
             let rawMouse = d3.pointer(event, view.svg.node());
             let mouse = [ view.x.invert(rawMouse[0]).valueOf(), view.y.invert(rawMouse[1]) ];
@@ -251,7 +255,7 @@ export default class LineGraph extends Chart {
             });
 
             view.svg.select("g#lines").selectAll("path").each(function() {
-                d3.select(this).attr("stroke", s => s.gisJoin === closest.gisJoin ? 'steelblue' : '#eee');
+                d3.select(this).attr("stroke", s => s.gisJoin === closest.gisJoin ? 'steelblue' : chart.getInvertedThemeColor());
             });
 
             let textSpaceTolerance = closest.name.length * 7;
@@ -261,6 +265,7 @@ export default class LineGraph extends Chart {
                 .attr("x", ((rawMouse[0] - this.views[0].width) > -textSpaceTolerance) ? rawMouse[0] - textSpaceTolerance : rawMouse[0])
                 .attr("y", rawMouse[1] - 20)
                 .attr("font-size", "smaller")
+                .attr("fill", this.getBasicThemeColor())
                 .text(closest.name);
         });
 

--- a/src/js/library/charting/scatterplot.js
+++ b/src/js/library/charting/scatterplot.js
@@ -122,6 +122,7 @@ export default class Scatterplot extends Chart {
             .attr("y", newHeight - view.margin.bottom / 2 + 4)
             .attr("text-anchor", "end")
             .attr("font-size", "8pt")
+            .attr("fill", this.getBasicThemeColor())
             .text(this.data.x);
 
         view.svg.select("text#yAxisLabel")
@@ -129,6 +130,7 @@ export default class Scatterplot extends Chart {
             .attr("y", view.margin.top / 2)
             .attr("text-anchor", "start")
             .attr("font-size", "8pt")
+            .attr("fill", this.getBasicThemeColor())
             .text(this.data.y);
     }
 

--- a/src/js/library/resizable.js
+++ b/src/js/library/resizable.js
@@ -248,11 +248,15 @@ export default class resizable {
         if (enough_width) {
             this.overlayDocument.style.width = this.width + 'px';
             this.overlayDocument.style.left = leftOffset + 'px';
+        } else {
+            this.width = resizable.minimum_width;
         }
 
         if (enough_height) {
             this.overlayDocument.style.height = this.height + 'px';
             this.overlayDocument.style.top = topOffset + 'px';
+        } else {
+            this.height = resizable.minimum_height;
         }
 
         if (enough_width && enough_height && this.onResizeCallback) {

--- a/src/js/static/darkMode.js
+++ b/src/js/static/darkMode.js
@@ -10,6 +10,11 @@ function switchTheme(e) {
 	else {
 		document.documentElement.setAttribute('data-theme', 'light');
 	}
+
 	switchImageSources();
+
+    if (window.chartSystem) {
+        window.chartSystem.update()
+    }
 }
 toggleSwitch.addEventListener('change', switchTheme, false);


### PR DESCRIPTION
All charts should now respect dark mode (#308). In doing this, I also had to fix #307, so you get it for free.
Also, lag on the client should be reduced, especially in COVID charts, since queries no longer happen every 2 seconds. Now that timer runs every 1.5 seconds and only does re-rendering of chart frames, nothing more.