### PR TITLE
Add KDE to ported histogram

### DIFF
--- a/src/js/ui/NewCharting/ChartTemplates/HistogramChart.js
+++ b/src/js/ui/NewCharting/ChartTemplates/HistogramChart.js
@@ -23,6 +23,7 @@ export default function HistogramGraph(props) {
     }
 
     let rerender = (width, height) => {
+        kde.setBandwidth(props.bandwidth)
 
         if (!props.data || !props.selected) {
             return;

--- a/src/js/ui/NewCharting/ChartTemplates/HistogramChart.js
+++ b/src/js/ui/NewCharting/ChartTemplates/HistogramChart.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import * as d3 from '../../../third-party/d3.min.js';
 import KernelDensityEstimator from '../../../library/charting/kernelDensityEstimator';
 
-export default function Histogram(props) {
+export default function HistogramGraph(props) {
 
     let svgRef = React.createRef();
     let [margin, setMargin] = useState({ top: 0, right: 10, bottom: 150, left: 20 });

--- a/src/js/ui/NewCharting/ChartTemplates/HistogramChart.js
+++ b/src/js/ui/NewCharting/ChartTemplates/HistogramChart.js
@@ -6,8 +6,7 @@ export default function HistogramGraph(props) {
 
     let svgRef = React.createRef();
     let [margin, setMargin] = useState({ top: 0, right: 10, bottom: 150, left: 20 });
-
-    let [kdeEnabled, setKdeEnabled] = useState(false);
+    let [kde, setKde] = useState(new KernelDensityEstimator());
 
     let setup = () => {
         let svg = d3.select(svgRef.current);
@@ -70,25 +69,24 @@ export default function HistogramGraph(props) {
             .attr("fill", "#eee")
             .text("TITLE");
 
-        /*
-        if (kdeEnabled) {
-            let maxBarHeight = d3.max(this.bins, d => d.length);
-            let kdePoints = this.kde.estimate(view.x.ticks(30), this.data, maxBarHeight);
+        if (props.kdeEnabled) {
+            let maxBarHeight = d3.max(bins, d => d.length);
+            let kdePoints = kde.estimate(x.ticks(30), data, maxBarHeight);
 
-            view.kdeLine = d3.line()
+            let kdeLine = d3.line()
                 .curve(d3.curveBasis)
-                .x(d => view.x(d[0]))
-                .y(d => view.y(d[1]));
-            view.svg.select("path#kdecurve")
+                .x(d => x(d[0]))
+                .y(d => y(d[1]));
+            svg.select("path#kdecurve")
                 .datum(kdePoints)
-                .attr("stroke", this.getBasicThemeColor())
-                .attr("d", view.kdeLine)
+                .attr("stroke", "#111")
+                .attr("fill", "none")
+                .attr("d", kdeLine)
                 .attr("display", "default");
         } else {
-            view.svg.select("path#kdecurve")
+            svg.select("path#kdecurve")
                 .attr("display", "none");
         }
-        */
     }
 
     useEffect(setup, []);

--- a/src/js/ui/NewCharting/ChartingResizable.js
+++ b/src/js/ui/NewCharting/ChartingResizable.js
@@ -4,11 +4,11 @@ import Paper from '@material-ui/core/Paper';
 import ChartingWindow from './ChartingWindow';
 
 function shouldAvoidDragging(node) {
-    if (!node || !node.className) {
+    if (!node || !node.className || !node.className.includes) {
         return false;
     }
 
-    const avoidClasses = [ "MuiSlider" ];
+    const avoidClasses = [ "MuiSlider", "MuiInput" ];
     return avoidClasses.some(_class => node.className.includes(_class));
 }
 

--- a/src/js/ui/NewCharting/ChartingResizable.js
+++ b/src/js/ui/NewCharting/ChartingResizable.js
@@ -4,6 +4,10 @@ import Paper from '@material-ui/core/Paper';
 import ChartingWindow from './ChartingWindow';
 
 function shouldAvoidDragging(node) {
+    if (!node || !node.target || !node.target.className) {
+        return false;
+    }
+
     const avoidClasses = [ "MuiSlider" ];
     return avoidClasses.some(_class => node.className.includes(_class));
 }

--- a/src/js/ui/NewCharting/ChartingResizable.js
+++ b/src/js/ui/NewCharting/ChartingResizable.js
@@ -9,13 +9,10 @@ export default function ChartingResizable() {
     let [size, setSize] = useState({ width: 500, height: 400 });
     let [chartData, setChartData] = useState({});
 
-
     useEffect(() => {
         window.chartSystem.registerDataConsumer('charting-resizable', setChartData);
         return () => window.chartSystem.unregisterDataConsumer('charting-resizable');
     }, []);
-
-
 
     return (
         <div style={{

--- a/src/js/ui/NewCharting/ChartingResizable.js
+++ b/src/js/ui/NewCharting/ChartingResizable.js
@@ -4,7 +4,7 @@ import Paper from '@material-ui/core/Paper';
 import ChartingWindow from './ChartingWindow';
 
 function shouldAvoidDragging(node) {
-    if (!node || !node.target || !node.target.className) {
+    if (!node || !node.className) {
         return false;
     }
 

--- a/src/js/ui/NewCharting/ChartingResizable.js
+++ b/src/js/ui/NewCharting/ChartingResizable.js
@@ -3,7 +3,10 @@ import { Rnd } from 'react-rnd';
 import Paper from '@material-ui/core/Paper';
 import ChartingWindow from './ChartingWindow';
 
-
+function shouldAvoidDragging(node) {
+    const avoidClasses = [ "MuiSlider" ];
+    return avoidClasses.some(_class => node.className.includes(_class));
+}
 
 export default function ChartingResizable() {
     let [size, setSize] = useState({ width: 500, height: 400 });
@@ -33,6 +36,9 @@ export default function ChartingResizable() {
                 bounds="window"
                 onResizeStop={(e, dir, refToElement, delta, position) => {
                     setSize({ width: size.width + delta.width, height: size.height + delta.height});
+                }}
+                onDrag={(node, x, y, deltaX, deltaY, lastX, lastY) => {
+                    return !shouldAvoidDragging(node.target);
                 }}
             >
                 <Paper className={'charting-resizable-window'}>

--- a/src/js/ui/NewCharting/KDEWrapper.js
+++ b/src/js/ui/NewCharting/KDEWrapper.js
@@ -23,6 +23,9 @@ export default function KDEWrapper(props) {
                     <Slider 
                         value={bandwidth}
                         onChange={handleChange(setBandwidth)}
+                        step={0.1}
+                        min={0.1}
+                        max={10}
                         aria-labelledby="input-slider"
                     />
                 </Grid>
@@ -35,6 +38,7 @@ export default function KDEWrapper(props) {
                             step: 0.1,
                             min: 0.1,
                             max: 10,
+                            'aria-labelledby': "input-slider"
                         }}
                     />
                 </Grid>

--- a/src/js/ui/NewCharting/KDEWrapper.js
+++ b/src/js/ui/NewCharting/KDEWrapper.js
@@ -1,21 +1,27 @@
 import React, { useState } from 'react';
 import Slider from '@material-ui/core/Slider';
 import Input from '@material-ui/core/Input';
+import Checkbox from '@material-ui/core/Checkbox';
 
 export default function KDEWrapper(props) {
+    let [enabled, setEnabled] = useState(false)
     let [bandwidth, setBandwidth] = useState(0.1);
 
-    const handleChange = (event, newValue) => setBandwidth(newValue);
+    const handleChange = setter => (event, newValue) => setter(newValue);
 
     return (
         <div>
+            <Checkbox
+                onChange={handleChange(setEnabled)}
+                checked={enabled}
+            />
             <Slider 
                 value={bandwidth}
-                onChange={handleChange}
+                onChange={handleChange(setBandwidth)}
                 aria-labelledby="input-slider"
             />
             {React.Children.map(props.children, child =>
-                React.cloneElement(child, { bandwidth: bandwidth, kdeEnabled: true })
+                React.cloneElement(child, { bandwidth: bandwidth, kdeEnabled: enabled })
             )}
         </div>
     );

--- a/src/js/ui/NewCharting/KDEWrapper.js
+++ b/src/js/ui/NewCharting/KDEWrapper.js
@@ -14,7 +14,9 @@ export default function KDEWrapper(props) {
                 onChange={handleChange}
                 aria-labelledby="input-slider"
             />
-            { props.children }
+            {React.Children.map(props.children, child =>
+                React.cloneElement(child, { bandwidth: bandwidth, kdeEnabled: true })
+            )}
         </div>
     );
 }

--- a/src/js/ui/NewCharting/KDEWrapper.js
+++ b/src/js/ui/NewCharting/KDEWrapper.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Grid from '@material-ui/core/Grid';
 import Slider from '@material-ui/core/Slider';
 import Input from '@material-ui/core/Input';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -11,15 +12,33 @@ export default function KDEWrapper(props) {
 
     return (
         <div>
-            <Checkbox
-                onChange={handleChange(setEnabled)}
-                checked={enabled}
-            />
-            <Slider 
-                value={bandwidth}
-                onChange={handleChange(setBandwidth)}
-                aria-labelledby="input-slider"
-            />
+            <Grid container spacing={2} alignItems="center">
+                <Grid item>
+                    <Checkbox
+                        onChange={handleChange(setEnabled)}
+                        checked={enabled}
+                    />
+                </Grid>
+                <Grid item xs>
+                    <Slider 
+                        value={bandwidth}
+                        onChange={handleChange(setBandwidth)}
+                        aria-labelledby="input-slider"
+                    />
+                </Grid>
+                <Grid item xs>
+                    <Input 
+                        value={bandwidth}
+                        onChange={handleChange(setBandwidth)}
+                        inputProps={{
+                            type: 'number',
+                            step: 0.1,
+                            min: 0.1,
+                            max: 10,
+                        }}
+                    />
+                </Grid>
+            </Grid>
             {React.Children.map(props.children, child =>
                 React.cloneElement(child, { bandwidth: bandwidth, kdeEnabled: enabled })
             )}

--- a/src/js/ui/NewCharting/KDEWrapper.js
+++ b/src/js/ui/NewCharting/KDEWrapper.js
@@ -4,11 +4,26 @@ import Slider from '@material-ui/core/Slider';
 import Input from '@material-ui/core/Input';
 import Checkbox from '@material-ui/core/Checkbox';
 
+const MIN_BANDWIDTH = 0.1
+const MAX_BANDWIDTH = 10
+const BANDWIDTH_STEP = 0.1
+
 export default function KDEWrapper(props) {
     let [enabled, setEnabled] = useState(false)
     let [bandwidth, setBandwidth] = useState(0.1);
 
     const handleChange = setter => (event, newValue) => setter(newValue);
+    const handleEvent = setter => event => {
+        let value = event.target.value;
+        setter(value === '' ? '' : Number(value));
+    };
+    const clampValue = (setter, value, min, max) => () => {
+        if (value < min) {
+            setter(min);
+        } else if (value > max) {
+            setter(max);
+        }
+    }
 
     return (
         <div>
@@ -23,21 +38,22 @@ export default function KDEWrapper(props) {
                     <Slider 
                         value={bandwidth}
                         onChange={handleChange(setBandwidth)}
-                        step={0.1}
-                        min={0.1}
-                        max={10}
+                        step={BANDWIDTH_STEP}
+                        min={MIN_BANDWIDTH}
+                        max={MAX_BANDWIDTH}
                         aria-labelledby="input-slider"
                     />
                 </Grid>
                 <Grid item xs>
                     <Input 
                         value={bandwidth}
-                        onChange={handleChange(setBandwidth)}
+                        onChange={handleEvent(setBandwidth)}
+                        onBlur={clampValue(setBandwidth, bandwidth, MIN_BANDWIDTH, MAX_BANDWIDTH)}
                         inputProps={{
                             type: 'number',
-                            step: 0.1,
-                            min: 0.1,
-                            max: 10,
+                            step: BANDWIDTH_STEP,
+                            min: MIN_BANDWIDTH,
+                            max: MAX_BANDWIDTH,
                             'aria-labelledby': "input-slider"
                         }}
                     />

--- a/src/js/ui/NewCharting/KDEWrapper.js
+++ b/src/js/ui/NewCharting/KDEWrapper.js
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+import Slider from '@material-ui/core/Slider';
+import Input from '@material-ui/core/Input';
+
+export default function KDEWrapper(props) {
+    let [bandwidth, setBandwidth] = useState(0.1);
+
+    const handleChange = (event, newValue) => setBandwidth(newValue);
+
+    return (
+        <div>
+            <Slider 
+                value={bandwidth}
+                onChange={handleChange}
+                aria-labelledby="input-slider"
+            />
+            { props.children }
+        </div>
+    );
+}

--- a/src/js/ui/NewCharting/makeFrame.js
+++ b/src/js/ui/NewCharting/makeFrame.js
@@ -4,6 +4,7 @@ import ConstraintDropDown from "./constraintDropDown"
 import LineGraph from "./ChartTemplates/LineGraph"
 import PieGraph from "./ChartTemplates/PieTEST";
 import ScatterPlot from "./ChartTemplates/ScatterPlot";
+import KDEWrapper from "./KDEWrapper";
 
 export default function Frame(props) {
     const [id, setID] = useState(`${props.type.name}-frame-${Math.random().toString(36).substring(2, 6)}`);
@@ -21,18 +22,25 @@ export default function Frame(props) {
     }
     switch (props.type.name) {
         case "histogram":
-            frame = <div>
-                <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
-                <HistogramGraph size={props.size} data={props.data} selected={constraint}></HistogramGraph></div>; break;
+            frame = 
+                <div>
+                    <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
+                    <KDEWrapper>
+                        <HistogramGraph size={props.size} data={props.data} selected={constraint}></HistogramGraph>
+                    </KDEWrapper>
+                </div>;
+                break;
         case "line":
             frame = <LineGraph size={props.size} data={props.data} selected={constraint}></LineGraph>; break;
         case "pie":
             frame = <PieGraph size={props.size} data={props.data} selected={constraint}></PieGraph>; break;
         case "scatterplot":
-            frame = <div>
-                <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
-                <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint2}></ConstraintDropDown>
-                <ScatterPlot size={props.size} data={props.data} selected={[constraint, constraint2]}></ScatterPlot></div>; break;
+            frame = 
+                <div>
+                    <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
+                    <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint2}></ConstraintDropDown>
+                    <ScatterPlot size={props.size} data={props.data} selected={[constraint, constraint2]}></ScatterPlot>
+                </div>; break;
         default: break;
     }
 


### PR DESCRIPTION
This re-introduces KDE to histograms in a React-friendly way.
Known issue: the Input up/down buttons don't work on Firefox. No idea why - I think it honestly might be a bug in MaterialUI.