### PR TITLE
Reimplement covid line tooltips

### DIFF
--- a/src/css/charts.css
+++ b/src/css/charts.css
@@ -3,6 +3,10 @@
     width: 100%;
 }
 
+.charting-resizable-window svg {
+    cursor: normal;
+}
+
 .add-graph-box {
     padding: 20px;
     border-bottom-style: double;

--- a/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
+++ b/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
@@ -103,9 +103,10 @@ export default function LineGraph(props) {
 
 
         onMouseMove = event => {
-            console.log(event);
-            //let rawMouse = d3.pointer(event, svgRef.current);
-            let rawMouse = [event.layerX, event.layerY];
+            let rawMouse = d3.pointer(event, svgRef.current);
+
+            rawMouse[0] -= props.pos.x / svgRef.current.getScreenCTM().a;
+            rawMouse[1] -= props.pos.y / svgRef.current.getScreenCTM().d;
 
             let mouse = [ x.invert(rawMouse[0]).valueOf(), y.invert(rawMouse[1]) ];
 

--- a/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
+++ b/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
@@ -103,7 +103,10 @@ export default function LineGraph(props) {
 
 
         onMouseMove = event => {
-            let rawMouse = d3.pointer(event, svgRef.current);
+            console.log(event);
+            //let rawMouse = d3.pointer(event, svgRef.current);
+            let rawMouse = [event.layerX, event.layerY];
+
             let mouse = [ x.invert(rawMouse[0]).valueOf(), y.invert(rawMouse[1]) ];
 
             let dates = [];

--- a/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
+++ b/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
@@ -102,16 +102,20 @@ export default function LineGraph(props) {
 
 
         onMouseMove = event => {
-            // Hello darkness my old friend
             if (svgRef.current == null) {
                 return;
             }
 
             let rawMouse = d3.pointer(event, svgRef.current);
-            
-            // I've come to speak with you again
-            rawMouse[0] -= props.pos.x / svgRef.current.getScreenCTM().a;
-            rawMouse[1] -= props.pos.y / svgRef.current.getScreenCTM().d;
+            console.log(rawMouse);
+
+            // d3.pointer does not give accurate reuslts on some browsers,
+            // If rawMouse is outside the resizable window, adjust it.
+            if (rawMouse[0] > props.size.width || rawMouse[1] > props.size.height) {
+                rawMouse[0] -= props.pos.x / svgRef.current.getScreenCTM().a;
+                rawMouse[1] -= props.pos.y / svgRef.current.getScreenCTM().d;
+                //console.log(rawMouse);
+            }
 
             let mouse = [ x.invert(rawMouse[0]).valueOf(), y.invert(rawMouse[1]) ];
 

--- a/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
+++ b/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
@@ -31,7 +31,6 @@ export default function LineGraph(props) {
 
 		svg.on('mouseenter', (event) => { mouseIn = true; });
         svg.on('mouseleave', (event) => {
-            console.log(event);
             mouseIn = false;
             svg.select("text#marker").attr("display", "none");
             svg.select("g#lines").selectAll("path").each(function() {
@@ -103,8 +102,14 @@ export default function LineGraph(props) {
 
 
         onMouseMove = event => {
-            let rawMouse = d3.pointer(event, svgRef.current);
+            // Hello darkness my old friend
+            if (svgRef.current == null) {
+                return;
+            }
 
+            let rawMouse = d3.pointer(event, svgRef.current);
+            
+            // I've come to speak with you again
             rawMouse[0] -= props.pos.x / svgRef.current.getScreenCTM().a;
             rawMouse[1] -= props.pos.y / svgRef.current.getScreenCTM().d;
 

--- a/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
+++ b/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
@@ -6,8 +6,9 @@ export default function LineGraph(props) {
     let svgRef = React.createRef();
 
     let [margin, setMargin] = useState({ top: 30, right: 20, bottom: 75, left: 50 });
-    let [mouseIn, setMouseIn] = useState(false);
-	let [onMouseMove, setOnMouseMove] = useState(() => {});
+
+    let mouseIn = false;
+    let onMouseMove = () => {};
     
     let setup = () => {
         let svg = d3.select(svgRef.current);
@@ -28,9 +29,10 @@ export default function LineGraph(props) {
             .attr("fill", "#666")
             .text("getting data...");
 
-		svg.on('mouseenter', () => setMouseIn(true));
-        svg.on('mouseleave', () => {
-            setMouseIn(false);
+		svg.on('mouseenter', (event) => { mouseIn = true; });
+        svg.on('mouseleave', (event) => {
+            console.log(event);
+            mouseIn = false;
             svg.select("text#marker").attr("display", "none");
             svg.select("g#lines").selectAll("path").each(function() {
                 d3.select(this).attr("stroke", "steelblue");
@@ -98,10 +100,9 @@ export default function LineGraph(props) {
             .attr("x", width / 2)
             .attr("fill", "#666")
             .text("SUBTITLE");
-        
-        setOnMouseMove(event => {
-			return;
 
+
+        onMouseMove = event => {
             let rawMouse = d3.pointer(event, svgRef.current);
             let mouse = [ x.invert(rawMouse[0]).valueOf(), y.invert(rawMouse[1]) ];
 
@@ -139,17 +140,8 @@ export default function LineGraph(props) {
                 .attr("font-size", "smaller")
                 .attr("fill", "#111")
                 .text(closest.name);
-        });
-
-        /*
-        if (this.makingQuery && !this.lastDataFailed) {
-            view.svg.select("text#queryNotice")
-                .attr("display", "default");
-        } else {
-            view.svg.select("text#queryNotice")
-                .attr("display", "none");
-        }
-        */
+        };
+        svg.on('mousemove', onMouseMove);
     };
 
     useEffect(setup, []);

--- a/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
+++ b/src/js/ui/NewCharting/ChartTemplates/LineGraph.js
@@ -107,14 +107,12 @@ export default function LineGraph(props) {
             }
 
             let rawMouse = d3.pointer(event, svgRef.current);
-            console.log(rawMouse);
 
             // d3.pointer does not give accurate reuslts on some browsers,
             // If rawMouse is outside the resizable window, adjust it.
             if (rawMouse[0] > props.size.width || rawMouse[1] > props.size.height) {
                 rawMouse[0] -= props.pos.x / svgRef.current.getScreenCTM().a;
                 rawMouse[1] -= props.pos.y / svgRef.current.getScreenCTM().d;
-                //console.log(rawMouse);
             }
 
             let mouse = [ x.invert(rawMouse[0]).valueOf(), y.invert(rawMouse[1]) ];

--- a/src/js/ui/NewCharting/ChartingResizable.js
+++ b/src/js/ui/NewCharting/ChartingResizable.js
@@ -14,6 +14,7 @@ function shouldAvoidDragging(node) {
 
 export default function ChartingResizable() {
     let [size, setSize] = useState({ width: 500, height: 400 });
+    let [pos, setPos] = useState({ x: 900, y: 100 });
     let [chartData, setChartData] = useState({});
 
     useEffect(() => {
@@ -46,10 +47,14 @@ export default function ChartingResizable() {
                 onDrag={(node, x, y, deltaX, deltaY, lastX, lastY) => {
                     return !shouldAvoidDragging(node.target);
                 }}
+                onDragStop={(node, x, y, deltaX, deltaY, lastX, lastY) => {
+                    // Yes, this is not a mistake, the library is bugged.
+                    setPos({ x: x.x, y: x.y });
+                }}
             >
                 <Paper className={'charting-resizable-window'}>
                     <div style={{ overflowY: "scroll", maxHeight: size.height }}>
-                        <ChartingWindow size={size} data={chartData}/>
+                        <ChartingWindow size={size} pos={pos} data={chartData}/>
                     </div>
                 </Paper>
             </Rnd>

--- a/src/js/ui/NewCharting/ChartingWindow.js
+++ b/src/js/ui/NewCharting/ChartingWindow.js
@@ -14,7 +14,7 @@ export default function ChartingWindow(props) {
             <Grid container direction="row" alignItems="center" justify="center" spacing={1}>
                 <Grid container direction="column" alignItems="center" justify="center" style={{ width: "90%" }}>
                     <ChartGlobalControls make={addChartFrame} />
-                    {frames.map((frameType, index) => <Frame key={index} type={frameType} size={props.size} data={props.data}/>)}
+                    {frames.map((frameType, index) => <Frame key={index} type={frameType} size={props.size} pos={props.pos} data={props.data}/>)}
                 </Grid>
             </Grid>
         </Grid>

--- a/src/js/ui/NewCharting/makeFrame.js
+++ b/src/js/ui/NewCharting/makeFrame.js
@@ -21,38 +21,44 @@ export default function Frame(props) {
             }
         })
     }
-    switch (props.type.name) {
 
+    let wrapWithDropDown = (component, opts, setc) => {
+        return (
+            <div>
+                <ConstraintDropDown options={opts} setConstraint={setc}/>
+                {component}
+            </div>
+        );
+    }
+
+    switch (props.type.name) {
         case "histogram":
             frame = 
-                <div>
-                    <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
-                    <KDEWrapper>
-                        <HistogramGraph size={props.size} pos={props.pos} data={props.data} selected={constraint}></HistogramGraph>
-                    </KDEWrapper>
-                </div>;
-                break;
+                <KDEWrapper>
+                    <HistogramGraph size={props.size} pos={props.pos} data={props.data} selected={constraint}/>
+                </KDEWrapper>
+            frame = wrapWithDropDown(frame, selectedConstraints, setConstraint);
+            break;
         case "line":
-            frame = <LineGraph size={props.size} pos={props.pos} data={props.data} selected={constraint}></LineGraph>; break;
+            frame = <LineGraph size={props.size} pos={props.pos} data={props.data} selected={constraint}/>;
+            break;
         case "piegraph2":
-            frame = <div><ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
-                <PieGraph size={props.size} pos={props.pos} data={props.data} selected={constraint}></PieGraph></div>; break;
+            frame = <PieGraph size={props.size} pos={props.pos} data={props.data} selected={constraint}/>; 
+            frame = wrapWithDropDown(frame, selectedConstraints, setConstraint);
+            break;
         case "scatterplot":
-            frame = 
-                <div>
-                    <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
-                    <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint2}></ConstraintDropDown>
-                    <ScatterPlot size={props.size} pos={props.pos} data={props.data} selected={[constraint, constraint2]}></ScatterPlot>
-                </div>; break;
+            frame =  <ScatterPlot size={props.size} pos={props.pos} data={props.data} selected={[constraint, constraint2]}/>
+            frame = wrapWithDropDown(frame, selectedConstraints, setConstraint);
+            frame = wrapWithDropDown(frame, selectedConstraints, setConstraint2);
+            break;
         case "piegraph":
-            frame = <div><ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
-                <BoxPlot size={props.size} pos={props.pos} data={props.data} selected={constraint}></BoxPlot></div>; break;
-
+            frame = <BoxPlot size={props.size} pos={props.pos} data={props.data} selected={constraint}/>;
+            frame = wrapWithDropDown(frame, selectedConstraints, setConstraint);
+            break;
         default: break;
     }
 
     return (
-
         <div style={{
             width: "100%",
             height: props.size.height - 80,

--- a/src/js/ui/NewCharting/makeFrame.js
+++ b/src/js/ui/NewCharting/makeFrame.js
@@ -28,25 +28,25 @@ export default function Frame(props) {
                 <div>
                     <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
                     <KDEWrapper>
-                        <HistogramGraph size={props.size} data={props.data} selected={constraint}></HistogramGraph>
+                        <HistogramGraph size={props.size} pos={props.pos} data={props.data} selected={constraint}></HistogramGraph>
                     </KDEWrapper>
                 </div>;
                 break;
         case "line":
-            frame = <LineGraph size={props.size} data={props.data} selected={constraint}></LineGraph>; break;
+            frame = <LineGraph size={props.size} pos={props.pos} data={props.data} selected={constraint}></LineGraph>; break;
         case "piegraph2":
             frame = <div><ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
-                <PieGraph size={props.size} data={props.data} selected={constraint}></PieGraph></div>; break;
+                <PieGraph size={props.size} pos={props.pos} data={props.data} selected={constraint}></PieGraph></div>; break;
         case "scatterplot":
             frame = 
                 <div>
                     <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
                     <ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint2}></ConstraintDropDown>
-                    <ScatterPlot size={props.size} data={props.data} selected={[constraint, constraint2]}></ScatterPlot>
+                    <ScatterPlot size={props.size} pos={props.pos} data={props.data} selected={[constraint, constraint2]}></ScatterPlot>
                 </div>; break;
         case "piegraph":
             frame = <div><ConstraintDropDown options={selectedConstraints} setConstraint={setConstraint}></ConstraintDropDown>
-                <BoxPlot size={props.size} data={props.data} selected={constraint}></BoxPlot></div>; break;
+                <BoxPlot size={props.size} pos={props.pos} data={props.data} selected={constraint}></BoxPlot></div>; break;
 
         default: break;
     }


### PR DESCRIPTION
Returns the old functionality where you could hover over lines in the COVID chart to see what county there were a part of.

The Rnd component made this an _absolutely colossal_ pain, for more reasons than one. Please test thoroughly, as this fix definitely involves some really hacky duct-tape solutions.

Closes #361.

