### PR TITLE
Fix unresponsive hovering on covid graph

### DIFF
--- a/src/js/ui/NewCharting/ChartingWindow.js
+++ b/src/js/ui/NewCharting/ChartingWindow.js
@@ -77,7 +77,7 @@ export default function ChartingWindow(props) {
                 <Grid container direction="column" alignItems="center" justify="center" style={{ width: "90%" }}>
                     <ChartGlobalControls make={addChartFrame} />
                       
-                    {frames.map((frameType, index) => <Frame key={index} type={frameType} index={index} size={props.size} remove={removeChartFrame} data={props.data}/>)}
+                    {frames.map((frameType, index) => <Frame key={index} pos={props.pos} type={frameType} index={index} size={props.size} remove={removeChartFrame} data={props.data}/>)}
 
                 </Grid>
             </Grid>

--- a/src/js/ui/NewCharting/makeFrame.js
+++ b/src/js/ui/NewCharting/makeFrame.js
@@ -106,7 +106,7 @@ export default function Frame(props) {
                 </div>;
                 break;
         case "line":
-            frame = <LineGraph size={props.size} data={props.data} selected={constraint}></LineGraph>; break;
+            frame = <LineGraph pos={props.pos} size={props.size} data={props.data} selected={constraint}></LineGraph>; break;
         case "piegraph":
             frame = <div><FrameControls index={props.index} remove={props.remove} options={selectedConstraints} setConstraint={setConstraint} numDropDowns={1}></FrameControls>
                 <PieGraph size={props.size} data={props.data} selected={constraint}></PieGraph></div>; break;


### PR DESCRIPTION
This _should_ address county hovering and highlighting not working - only tested on FF, so make sure it works on your browser first.