### PR TITLE
"Constraint" -> "Dataset"

### DIFF
--- a/src/js/ui/NewCharting/ChartTemplates/BoxPlotChart.js
+++ b/src/js/ui/NewCharting/ChartTemplates/BoxPlotChart.js
@@ -108,7 +108,7 @@ export default function BoxPlotChart(props){
         svg.select("#xAxis")
             .attr("transform", "translate(0," + 150 + ")")
             .call(d3.axisBottom(y));
-        var center = 100;
+        let center = 100;
         width = 50;
         svg.select("#line1")
             .attr("y1", center)
@@ -146,7 +146,7 @@ export default function BoxPlotChart(props){
 
     return (
         <div>
-            <svg ref={svgRef}></svg>
+            <svg ref={svgRef} />
         </div>
     );
 }

--- a/src/js/ui/NewCharting/FrameControls.js
+++ b/src/js/ui/NewCharting/FrameControls.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function FrameControls(props) {
     const classes = useStyles();
-    const dropdownNameOptions = ["Constraint", "X-Axis County", "X-Axis Tract", "Y-Axis County", "Y-Axis Tract"];
+    const dropdownNameOptions = ["Dataset", "X-Axis County", "X-Axis Tract", "Y-Axis County", "Y-Axis Tract"];
     const [tractOrCounty, setTractOrCounty] = useState(true);
     const [dropdownName1, setDropdownName1] = useState("");
     const [dropdownName2, setDropdownName2] = useState("");

--- a/src/js/ui/NewCharting/KDEWrapper.js
+++ b/src/js/ui/NewCharting/KDEWrapper.js
@@ -88,6 +88,7 @@ export default function KDEWrapper(props) {
             <Grid container spacing={2} alignItems="center">
                 <Grid item>
                     <Checkbox
+                        color="primary"
                         onChange={handleChange(setEnabled)}
                         checked={enabled}
                     />


### PR DESCRIPTION
Previously, the default name for a dropdown in Charting was "Constraint". It needs to be "Dataset" because we are charting datasets not constraints.

This PR also fixes a 'var' to a 'let' in Boxplot.js