### PR TITLE
Fix Bug Relating to Zooming and Changing Slider

### DIFF
--- a/src/js/library/autoQuery.js
+++ b/src/js/library/autoQuery.js
@@ -362,6 +362,7 @@ export default class AutoQuery {
             }
         }
 
+        this.currentQueries.add(id);
         Query.makeQuery({
             collection: this.collection,
             pipeline: this.buildConstraintPipeline(),
@@ -371,7 +372,6 @@ export default class AutoQuery {
             geohashBlacklist: this.geohashCache,
             id
         });
-        this.currentQueries.add(id);
     }
 
     zoomIsValid() {


### PR DESCRIPTION
Basically, a fix I made earlier made it so the query class could return immediately. The query id set was not populated yet once it returned, causing many issues. This populates the id set before the call is made.