### PR TITLE
gridMET time range goes up to yesterday

### DIFF
--- a/src/js/static/menuOverwrite.js
+++ b/src/js/static/menuOverwrite.js
@@ -60,6 +60,11 @@ END OF TERMS AND CONDITIONS
 import clone from 'just-clone';
 import Util from '../library/apertureUtil';
 
+function getEpochForYesterday() {
+    const oneDay = (1000 * 60 * 60 * 24);
+    return Date.now() - (oneDay + (Date.now() % oneDay));
+}
+
 const overwrite = { //leaving this commented cause it explains the schema really well 
     // "covid_county": {
     //     "group": "Tract, County, & State Data",
@@ -101,8 +106,8 @@ const overwrite = { //leaving this commented cause it explains the schema really
             time_interval: {
                 type: "slider",
                 label: "Date Range",
-                range: [283996800000, Date.now() - (1000 * 60 * 60 * 24)],
-                "default": [283996800000, Date.now() - (1000 * 60 * 60 * 24)],
+                range: [283996800000, getEpochForYesterday()],
+                "default": [283996800000, getEpochForYesterday()],
                 isDate: true
             },
             m_air_temperature_max: {

--- a/src/js/static/menuOverwrite.js
+++ b/src/js/static/menuOverwrite.js
@@ -101,8 +101,8 @@ const overwrite = { //leaving this commented cause it explains the schema really
             time_interval: {
                 type: "slider",
                 label: "Date Range",
-                range: [283996800000, 1577836800000],
-                "default": [283996800000, 315532800000],
+                range: [283996800000, Date.now() - (1000 * 60 * 60 * 24)],
+                "default": [283996800000, Date.now() - (1000 * 60 * 60 * 24)],
                 isDate: true
             },
             m_air_temperature_max: {


### PR DESCRIPTION
Lets users select dates up to yesterday for the gridMET dataset, since we will very soon be updating it regularly.