### PR TITLE
Ingest aqi datasets

### DIFF
--- a/src/json/menumetadata.json
+++ b/src/json/menumetadata.json
@@ -6931,6 +6931,31 @@
         ]
     },
     {
+        "collection": "epa_aqi_nitrogen",
+        "icon": "science",
+        "linked": {
+            "collection": "epa_aqi_monitors",
+            "field": "monitor_id"
+        },
+        "temporal": "epoch_time",
+        "source": "https://aqs.epa.gov/aqsweb/documents/data_api.html",
+        "label": "EPA AQI Monitors Nitrogen dioxide (NO2)",
+        "fieldMetadata": [
+            {
+                "name": "epoch_time",
+                "label": "Date",
+                "type": "date",
+                "step": "1hr"
+            },
+            {
+                "name": "sample",
+                "label": "Nitrogen dioxide (NO2)",
+                "unit": "Micrograms/cubic meter (LC)",
+                "temporal": true
+            }
+        ]
+    },
+    {
         "collection": "county_total_population",
         "level": "county",
         "color": {

--- a/src/json/menumetadata.json
+++ b/src/json/menumetadata.json
@@ -6939,7 +6939,7 @@
         },
         "temporal": "epoch_time",
         "source": "https://aqs.epa.gov/aqsweb/documents/data_api.html",
-        "label": "EPA AQI Monitors Nitrogen dioxide (NO2)",
+        "label": "EPA AQI Monitors Nitrogen Dioxide (NO2)",
         "fieldMetadata": [
             {
                 "name": "epoch_time",

--- a/src/json/menumetadata.json
+++ b/src/json/menumetadata.json
@@ -6881,6 +6881,31 @@
         ]
     },
     {
+        "collection": "epa_aqi_ozone",
+        "icon": "science",
+        "linked": {
+            "collection": "epa_aqi_monitors",
+            "field": "monitor_id"
+        },
+        "temporal": "epoch_time",
+        "source": "https://aqs.epa.gov/aqsweb/documents/data_api.html",
+        "label": "EPA AQI Monitors Ozone",
+        "fieldMetadata": [
+            {
+                "name": "epoch_time",
+                "label": "Date",
+                "type": "date",
+                "step": "1hr"
+            },
+            {
+                "name": "sample",
+                "label": "Ozone",
+                "unit": "Micrograms/cubic meter (LC)",
+                "temporal": true
+            }
+        ]
+    },
+    {
         "collection": "county_total_population",
         "level": "county",
         "color": {

--- a/src/json/menumetadata.json
+++ b/src/json/menumetadata.json
@@ -6806,6 +6806,81 @@
         ]
     },
     {
+        "collection": "epa_aqi_lead_tsp",
+        "icon": "science",
+        "linked": {
+            "collection": "epa_aqi_monitors",
+            "field": "monitor_id"
+        },
+        "temporal": "epoch_time",
+        "source": "https://aqs.epa.gov/aqsweb/documents/data_api.html",
+        "label": "EPA AQI Monitors Lead (TSP) LC",
+        "fieldMetadata": [
+            {
+                "name": "epoch_time",
+                "label": "Date",
+                "type": "date",
+                "step": "1hr"
+            },
+            {
+                "name": "sample",
+                "label": "Lead (TSP) LC",
+                "unit": "Micrograms/cubic meter (LC)",
+                "temporal": true
+            }
+        ]
+    },
+    {
+        "collection": "epa_aqi_lead_pm10",
+        "icon": "science",
+        "linked": {
+            "collection": "epa_aqi_monitors",
+            "field": "monitor_id"
+        },
+        "temporal": "epoch_time",
+        "source": "https://aqs.epa.gov/aqsweb/documents/data_api.html",
+        "label": "EPA AQI Monitors Lead PM10 LC FRM/FEM",
+        "fieldMetadata": [
+            {
+                "name": "epoch_time",
+                "label": "Date",
+                "type": "date",
+                "step": "1hr"
+            },
+            {
+                "name": "sample",
+                "label": "Lead PM10 LC FRM/FEM",
+                "unit": "Micrograms/cubic meter (LC)",
+                "temporal": true
+            }
+        ]
+    },
+    {
+        "collection": "epa_aqi_pm10_total",
+        "icon": "science",
+        "linked": {
+            "collection": "epa_aqi_monitors",
+            "field": "monitor_id"
+        },
+        "temporal": "epoch_time",
+        "source": "https://aqs.epa.gov/aqsweb/documents/data_api.html",
+        "label": "EPA AQI Monitors PM10 Total 0-10um STP",
+        "fieldMetadata": [
+            {
+                "name": "epoch_time",
+                "label": "Date",
+                "type": "date",
+                "step": "1hr"
+            },
+            {
+                "name": "sample",
+                "label": "PM10 Total 0-10um STP",
+                "unit": "Micrograms/cubic meter (LC)",
+                "temporal": true
+            }
+        ]
+    },
+    {
         "collection": "county_total_population",
         "level": "county",
         "color": {


### PR DESCRIPTION
This adds 6 of the 8 AQI Contaminants. They can be found by searching 'EPA' in the Aperture search bar. Shrideep wants to get these in this morning, if possible, for a PI meeting this afternoon.

Known issue: when a contaminant is added the icon does not automatically color-code - this must be selected in the inspection pane. Shrideep saw this and said it is fine for the time being. 

I will add the last 2 contaminants once they're done being ingested, hopefully by the end of the weekend.

Just check that you can see these 6 datasets, that they turn on, and it doesn't break anything.