### PR TITLE
Metadata for general aqi

### DIFF
--- a/src/js/library/Color.js
+++ b/src/js/library/Color.js
@@ -128,6 +128,16 @@ export default class Color {
             this.overrideColor = predefinedColor.colorCode;
             return;
         }
+        else if (predefinedColor.style === "aqi_special") {
+            const green = Array(10).fill("#00e400");
+            const yellow = Array(10).fill("#ffff00");
+            const orange = Array(10).fill("#ff7e00");
+            const red = Array(10).fill("#ff0000");
+            const purple = Array(20).fill("#8f3f97");
+            const cherry = Array(40).fill("#7e0023");
+            const aqi_colors = [...green, ...yellow, ...orange, ...red, ...purple, ...cherry];
+            this.gradient = aqi_colors;
+        }
         else if (predefinedColor.style === "gradient" && predefinedColor.gradient) {
             this.gradient = this._createGradient(predefinedColor.gradient)
         }
@@ -139,16 +149,6 @@ export default class Color {
         }
         else if (predefinedColor.style === "sequential" || this.options) {
             this._createDefaultColorMapping()
-        }
-        else if (predefinedColor.style === "aqi_special") {
-            const green = Array(10).fill("#00e400");
-            const yellow = Array(10).fill("#ffff00");
-            const orange = Array(10).fill("#ff7e00");
-            const red = Array(10).fill("#ff0000");
-            const purple = Array(20).fill("#8f3f97");
-            const cherry = Array(40).fill("#7e0023");
-            const aqi_colors = green.concat(yellow, orange, red, purple, cherry);
-            this.gradient = aqi_colors;
         }
     }
 

--- a/src/js/library/Color.js
+++ b/src/js/library/Color.js
@@ -141,16 +141,15 @@ export default class Color {
             this._createDefaultColorMapping()
         }
         else if (predefinedColor.style === "aqi_special") {
-            this.gradient = [ // FIXME Where do I put the logic to associate the aqi to the color?
-                "#00e400", // 0-50
-                "#ffff00", // 51-100
-                "#ff7e00", // 101-150
-                "#ff0000", // 151-200
-                "#8f3f97", // 201-300
-                "#7e0023"  // 301-500
-            ]
+            const green = Array(10).fill("#00e400");
+            const yellow = Array(10).fill("#ffff00");
+            const orange = Array(10).fill("#ff7e00");
+            const red = Array(10).fill("#ff0000");
+            const purple = Array(20).fill("#8f3f97");
+            const cherry = Array(40).fill("#7e0023");
+            const aqi_colors = green.concat(yellow, orange, red, purple, cherry);
+            this.gradient = aqi_colors;
         }
-        console.log(this.gradient)
     }
 
     _createGradient(gradientArr, resolution = 100) {

--- a/src/js/library/Color.js
+++ b/src/js/library/Color.js
@@ -140,6 +140,17 @@ export default class Color {
         else if (predefinedColor.style === "sequential" || this.options) {
             this._createDefaultColorMapping()
         }
+        else if (predefinedColor.style === "aqi_special") {
+            this.gradient = [ // FIXME Where do I put the logic to associate the aqi to the color?
+                "#00e400", // 0-50
+                "#ffff00", // 51-100
+                "#ff7e00", // 101-150
+                "#ff0000", // 151-200
+                "#8f3f97", // 201-300
+                "#7e0023"  // 301-500
+            ]
+        }
+        console.log(this.gradient)
     }
 
     _createGradient(gradientArr, resolution = 100) {

--- a/src/json/menumetadata.json
+++ b/src/json/menumetadata.json
@@ -7005,6 +7005,39 @@
             }
         ]
     },
+
+
+    {
+        "collection": "epa_aqi_general",
+        "label": "EPA AQI Score",
+        "temporal": "epoch_time",
+        "source": "https://aqs.epa.gov/aqsweb/documents/data_api.html",
+        "level": "county",
+        "fieldMetadata": [
+            {
+                "name": "epoch_time",
+                "label": "Year",
+                "step": "year"
+            },
+            {
+                "name": "GISJOIN",
+                "label": "GIS Join Match Code",
+                "hideByDefault": true
+            },
+            {
+                "name": "aqi",
+                "color": {
+                    "label": "aqi",
+                    "style": "aqi_special",
+                    "min": 0,
+                    "max": 500,
+                    "variable": "WHAT SHOULD THIS BE?"
+                }
+            }
+        ]
+    },
+
+
     {
         "collection": "county_total_population",
         "level": "county",
@@ -7389,5 +7422,4 @@
              }
     	]
     }
-    
 ]

--- a/src/json/menumetadata.json
+++ b/src/json/menumetadata.json
@@ -7012,6 +7012,10 @@
         "label": "EPA AQI Score",
         "temporal": "epoch_time",
         "source": "https://aqs.epa.gov/aqsweb/documents/data_api.html",
+        "color": {
+            "style": "aqi_special",
+            "variable": "aqi"
+        },
         "level": "county",
         "fieldMetadata": [
             {
@@ -7027,13 +7031,9 @@
             {
                 "name": "aqi",
                 "type": "range",
-                "color": {
-                    "label": "aqi",
-                    "style": "aqi_special",
-                    "min": 0,
-                    "max": 500,
-                    "variable": "aqi"
-                }
+                "min": 0,
+                "max": 500,
+                "temporal": "epoch_time"
             }
         ]
     },

--- a/src/json/menumetadata.json
+++ b/src/json/menumetadata.json
@@ -7031,7 +7031,7 @@
                     "style": "aqi_special",
                     "min": 0,
                     "max": 500,
-                    "variable": "WHAT SHOULD THIS BE?"
+                    "variable": "aqi"
                 }
             }
         ]

--- a/src/json/menumetadata.json
+++ b/src/json/menumetadata.json
@@ -7008,7 +7008,7 @@
 
 
     {
-        "collection": "epa_aqi_general",
+        "collection": "epa_aqi_general_score",
         "label": "EPA AQI Score",
         "temporal": "epoch_time",
         "source": "https://aqs.epa.gov/aqsweb/documents/data_api.html",
@@ -7026,6 +7026,7 @@
             },
             {
                 "name": "aqi",
+                "type": "range",
                 "color": {
                     "label": "aqi",
                     "style": "aqi_special",


### PR DESCRIPTION
Colors/graphing for the general aqi score. The dataset in aperture is called `EPA AQI Score`.
Some thoughts on this
- Aperture by default uses a date range for this dataset. This is wonderful in the inspection pane when you want to look at the graph of aqi over time for a given county
- The colors on the map only relate to the _first_ date in the date range. To me, this is less than intuitive.

I do think this is ready to merge, unless anyone finds a bug/other issue. I'd love to hear other opinions on the map coloring. Because this dataset does have both a range and a single-date visual component, I'm not sure about the best way to address this.