### PR TITLE
Update total datasets display

### DIFF
--- a/src/js/ui/NewDataExploration/WorkspaceControl/WorkspaceSearchbar.js
+++ b/src/js/ui/NewDataExploration/WorkspaceControl/WorkspaceSearchbar.js
@@ -228,7 +228,7 @@ export default React.memo(function WorkspaceSearchbar(props) {
     }
 
     function datasetHeaderText() {
-        return filtering ? `Found ${datasets.length} Results Matching '${filterText}'` : `${datasets.length} Datasets`;
+        return filtering ? `Found ${datasets.length} Results Matching '${filterText}'` : null;
     }
 
     function renderAddAllButton() {


### PR DESCRIPTION
Shrideep asked me to make this change to Aperture. It just removes the total_datasets field from the dataset explorer when the search bar is inactive. This is a 1-line change.